### PR TITLE
Timing info

### DIFF
--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -313,12 +313,15 @@ def print_stats(t):
 
     print_section_header('Clocks')
     max_freq = t.max_freq()
-    table_data = [['Clock domain', 'Actual freq']]
+    table_data = [['Clock domain', 'Actual freq', 'Requested freq', 'Met?']]
     if type(max_freq) is float:
         table_data.append(['Design', ("%0.3f MHz" % (max_freq / 1e6))])
     elif type(max_freq) is dict:
         for cd in max_freq:
-            table_data.append([cd, ("%0.3f MHz" % (max_freq[cd] / 1e6))])
+            actual = "%0.3f MHz" % (max_freq[cd]['actual'] / 1e6)
+            requested = "%0.3f MHz" % (max_freq[cd]['requested'] / 1e6)
+            met = max_freq[cd]['met']
+            table_data.append([cd, actual, requested, met])
 
     table = AsciiTable(table_data)
     print(table.table)

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -10,8 +10,8 @@ import shutil
 import sys
 import glob
 import datetime
-import asciitable
 import edalize
+from terminaltables import AsciiTable
 
 from toolchain import Toolchain
 from utils import Timed
@@ -282,33 +282,63 @@ class RadiantYosys(Radiant):
 
 
 def print_stats(t):
-    print('Design %s' % t.design())
-    print('  Family: %s' % t.family)
-    print('  Device: %s' % t.device)
-    print('  Package: %s' % t.package)
-    print('  Project: %s' % t.project_name)
-    print('  Toolchain: %s' % t.toolchain)
-    print('  Strategy: %s' % t.strategy)
-    print('  Carry: %s' % (t.carry, ))
+    def print_section_header(title):
+        print('')
+        print('===============================')
+        print(title)
+        print('===============================')
+        print('')
+
+    print_section_header('Setting')
+
+    table_data = [
+        ['Settings', 'Value'],
+        ['Design', t.design()],
+        ['Family', t.family],
+        ['Device', t.device],
+        ['Package', t.package],
+        ['Project', t.project_name],
+        ['Toolchain', t.toolchain],
+        ['Strategy', t.strategy],
+        ['Carry', t.carry],
+    ]
+
     if t.seed:
-        print('  Seed: 0x%08X (%u)' % (t.seed, t.seed))
+        table_data.append(['Seed', ('0x%08X (%u)' % (t.seed, t.seed))])
     else:
-        print('  Seed: default')
-    print('Timing:')
-    for k, v in t.runtimes.items():
-        print('  % -16s %0.3f' % (k + ':', v))
+        table_data.append(['Seed', 'default'])
+
+    table = AsciiTable(table_data)
+    print(table.table)
+
+    print_section_header('Clocks')
     max_freq = t.max_freq()
+    table_data = [['Clock domain', 'Actual freq']]
     if type(max_freq) is float:
-        print('Max frequency: %0.3f MHz' % (max_freq / 1e6, ))
+        table_data.append(['Design', ("%0.3f MHz" % (max_freq / 1e6))])
     elif type(max_freq) is dict:
         for cd in max_freq:
-            print(
-                'Max frequency in clock domain', cd,
-                '%0.3f MHz' % (max_freq[cd] / 1e6)
-            )
-    print('Resource utilization')
+            table_data.append([cd, ("%0.3f MHz" % (max_freq[cd] / 1e6))])
+
+    table = AsciiTable(table_data)
+    print(table.table)
+
+    print_section_header('Toolchain Resource Usage')
+    table_data = [['Stage', 'Run Time (seconds)']]
+    for k, v in t.runtimes.items():
+        table_data.append([k, ("%0.3f" % v)])
+
+    table = AsciiTable(table_data)
+    print(table.table)
+
+    print_section_header('FPGA resource utilization')
+    table_data = [['Resource', 'Used']]
+
     for k, v in sorted(t.resources().items()):
-        print('  %- 20s %s' % (k + ':', v))
+        table_data.append([k, v])
+
+    table = AsciiTable(table_data)
+    print(table.table)
 
 
 toolchains = {

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -313,7 +313,12 @@ def print_stats(t):
 
     print_section_header('Clocks')
     max_freq = t.max_freq()
-    table_data = [['Clock domain', 'Actual freq', 'Requested freq', 'Met?']]
+    table_data = [
+        [
+            'Clock domain', 'Actual freq', 'Requested freq', 'Met?',
+            'Setup violation', 'Hold violation'
+        ]
+    ]
     if type(max_freq) is float:
         table_data.append(['Design', ("%0.3f MHz" % (max_freq / 1e6))])
     elif type(max_freq) is dict:
@@ -321,7 +326,11 @@ def print_stats(t):
             actual = "%0.3f MHz" % (max_freq[cd]['actual'] / 1e6)
             requested = "%0.3f MHz" % (max_freq[cd]['requested'] / 1e6)
             met = max_freq[cd]['met']
-            table_data.append([cd, actual, requested, met])
+            s_violation = ("%0.3f ns" % max_freq[cd]['setup_violation'])
+            h_violation = ("%0.3f ns" % max_freq[cd]['hold_violation'])
+            table_data.append(
+                [cd, actual, requested, met, s_violation, h_violation]
+            )
 
     table = AsciiTable(table_data)
     print(table.table)

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -297,7 +297,15 @@ def print_stats(t):
     print('Timing:')
     for k, v in t.runtimes.items():
         print('  % -16s %0.3f' % (k + ':', v))
-    print('Max frequency: %0.3f MHz' % (t.max_freq() / 1e6, ))
+    max_freq = t.max_freq()
+    if type(max_freq) is float:
+        print('Max frequency: %0.3f MHz' % (max_freq / 1e6, ))
+    elif type(max_freq) is dict:
+        for cd in max_freq:
+            print(
+                'Max frequency in clock domain', cd,
+                '%0.3f MHz' % (max_freq[cd] / 1e6)
+            )
     print('Resource utilization')
     for k, v in sorted(t.resources().items()):
         print('  %- 20s %s' % (k + ':', v))

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -326,7 +326,12 @@ def print_stats(t):
     print_section_header('Toolchain Resource Usage')
     table_data = [['Stage', 'Run Time (seconds)']]
     for k, v in t.runtimes.items():
-        table_data.append([k, ("%0.3f" % v)])
+        if type(v) is collections.OrderedDict:
+            table_data.append([k, ""])
+            for k1, v1 in v.items():
+                table_data.append(["    " + k1, ("%0.3f" % v1)])
+        else:
+            table_data.append([k, ("%0.3f" % v)])
 
     table = AsciiTable(table_data)
     print(table.table)

--- a/src/baselitex/arty.sdc
+++ b/src/baselitex/arty.sdc
@@ -1,17 +1,8 @@
-# Input clock 100 MHz
-create_clock -period 10 clk100 -waveform {0.000 5.000}
-
 # Input clock BUFG 100 MHz
 create_clock -period 10 soc_clk100bg -waveform {0.000 5.000}
 
-# Input eth clock transmitter 25 MHz
-create_clock -period 40 eth_clocks_tx -waveform {0.000 20.000}
-
 # Input eth clock BUFG 25 MHz
 create_clock -period 40 eth_tx_clk -waveform {0.000 20.000}
-
-# Input eth clock receiver 25 MHz
-create_clock -period 40 eth_clocks_rx -waveform {0.000 20.000}
 
 # Input eth clock BUFG 25 MHz
 create_clock -period 40 eth_rx_clk -waveform {0.000 20.000}
@@ -46,7 +37,5 @@ create_clock -period 5 clk200_clk -waveform {0.000 2.500}
 # PLL CLKOUT4 25 MHz
 create_clock -period 40 soc_pll_clk100 -waveform {0.000 20.000}
 
-# BUFG CLKOUT4 25 MHz
-create_clock -period 40 eth_ref_clk -waveform {0.000 20.000}
 
-set_clock_groups -exclusive -group {clk100 soc_clk100bg soc_pll_fb} -group {soc_pll_sys sys_clk__VexRiscv.IBusCachedPlugin_cache.clk__VexRiscv.clk__VexRiscv.dataCache_1_.clk} -group {soc_pll_sys4x soc_pll_sys4x_dqs} -group {main_clkout3 clk200_clk} -group {eth_ref_clk eth_rx_clk eth_clocks_rx eth_tx_clk eth_clocks_tx}
+set_clock_groups -exclusive -group {soc_clk100bg soc_pll_fb} -group {soc_pll_sys sys_clk__VexRiscv.IBusCachedPlugin_cache.clk__VexRiscv.clk__VexRiscv.dataCache_1_.clk} -group {soc_pll_sys4x soc_pll_sys4x_dqs} -group {main_clkout3 clk200_clk} -group {eth_rx_clk eth_tx_clk}

--- a/src/baselitex/arty.sdc
+++ b/src/baselitex/arty.sdc
@@ -1,10 +1,52 @@
+# Input clock 100 MHz
 create_clock -period 10 clk100 -waveform {0.000 5.000}
+
+# Input clock BUFG 100 MHz
 create_clock -period 10 soc_clk100bg -waveform {0.000 5.000}
+
+# Input eth clock transmitter 25 MHz
+create_clock -period 40 eth_clocks_tx -waveform {0.000 20.000}
+
+# Input eth clock BUFG 25 MHz
+create_clock -period 40 eth_tx_clk -waveform {0.000 20.000}
+
+# Input eth clock receiver 25 MHz
+create_clock -period 40 eth_clocks_rx -waveform {0.000 20.000}
+
+# Input eth clock BUFG 25 MHz
+create_clock -period 40 eth_rx_clk -waveform {0.000 20.000}
+
+# PLL feedback loop 100 MHz
 create_clock -period 10 soc_pll_fb -waveform {0.000 5.000}
-create_clock -period 4.166 sys4x_clk -waveform {0.000 2.083}
-create_clock -period 4.166 sys4x_dqs_clk -waveform {1.041 3.124}
+
+# PLL CLKOUT0 60 MHz
 create_clock -period 16.666 soc_pll_sys -waveform {0.000 8.333}
+
+# BUFG CLKOUT0 60 MHz
 create_clock -period 16.666 sys_clk__VexRiscv.IBusCachedPlugin_cache.clk__VexRiscv.clk__VexRiscv.dataCache_1_.clk -waveform {0.000 8.333}
+
+# PLL CLKOUT1 240 MHz
 create_clock -period 4.166 soc_pll_sys4x  -waveform {0.000 2.083}
+
+# BUFG CLKOUT1 240 MHz
+create_clock -period 4.166 sys4x_clk -waveform {0.000 2.083}
+
+# PLL CLKOUT2 240 MHz
 create_clock -period 4.166 soc_pll_sys4x_dqs -waveform {1.041 3.124}
-set_clock_groups -exclusive -group {clk100 soc_clk100bg soc_pll_fb} -group {soc_pll_sys sys_clk__VexRiscv.IBusCachedPlugin_cache.clk__VexRiscv.clk__VexRiscv.dataCache_1_.clk} -group {soc_pll_sys4x soc_pll_sys4x_dqs}
+
+# BUFG CLKOUT2 240 MHz
+create_clock -period 4.166 sys4x_dqs_clk -waveform {1.041 3.124}
+
+# PLL CLKOUT3 200 MHz
+create_clock -period 5 soc_pll_clk200 -waveform {0.000 2.500}
+
+# BUFG CLKOUT3 200 MHz
+create_clock -period 5 clk200_clk -waveform {0.000 2.500}
+
+# PLL CLKOUT4 25 MHz
+create_clock -period 40 soc_pll_clk100 -waveform {0.000 20.000}
+
+# BUFG CLKOUT4 25 MHz
+create_clock -period 40 eth_ref_clk -waveform {0.000 20.000}
+
+set_clock_groups -exclusive -group {clk100 soc_clk100bg soc_pll_fb} -group {soc_pll_sys sys_clk__VexRiscv.IBusCachedPlugin_cache.clk__VexRiscv.clk__VexRiscv.dataCache_1_.clk} -group {soc_pll_sys4x soc_pll_sys4x_dqs} -group {main_clkout3 clk200_clk} -group {eth_ref_clk eth_rx_clk eth_clocks_rx eth_tx_clk eth_clocks_tx}

--- a/src/baselitex/arty.sdc
+++ b/src/baselitex/arty.sdc
@@ -1,11 +1,8 @@
+# Input clock 100 MHz
+create_clock -period 10 clk100_ibuf -waveform {0.000 5.000}
+
 # Input clock BUFG 100 MHz
 create_clock -period 10 soc_clk100bg -waveform {0.000 5.000}
-
-# Input eth clock BUFG 25 MHz
-create_clock -period 40 eth_tx_clk -waveform {0.000 20.000}
-
-# Input eth clock BUFG 25 MHz
-create_clock -period 40 eth_rx_clk -waveform {0.000 20.000}
 
 # PLL feedback loop 100 MHz
 create_clock -period 10 soc_pll_fb -waveform {0.000 5.000}
@@ -14,7 +11,7 @@ create_clock -period 10 soc_pll_fb -waveform {0.000 5.000}
 create_clock -period 16.666 soc_pll_sys -waveform {0.000 8.333}
 
 # BUFG CLKOUT0 60 MHz
-create_clock -period 16.666 sys_clk__VexRiscv.IBusCachedPlugin_cache.clk__VexRiscv.clk__VexRiscv.dataCache_1_.clk -waveform {0.000 8.333}
+create_clock -period 16.666 sys_clk -waveform {0.000 8.333}
 
 # PLL CLKOUT1 240 MHz
 create_clock -period 4.166 soc_pll_sys4x  -waveform {0.000 2.083}
@@ -37,5 +34,7 @@ create_clock -period 5 clk200_clk -waveform {0.000 2.500}
 # PLL CLKOUT4 25 MHz
 create_clock -period 40 soc_pll_clk100 -waveform {0.000 20.000}
 
+# BUFG CLKOUT4 25 MHz
+create_clock -period 40 eth_ref_clk_obuf -waveform {0.000 20.000}
 
-set_clock_groups -exclusive -group {soc_clk100bg soc_pll_fb} -group {soc_pll_sys sys_clk__VexRiscv.IBusCachedPlugin_cache.clk__VexRiscv.clk__VexRiscv.dataCache_1_.clk} -group {soc_pll_sys4x soc_pll_sys4x_dqs} -group {main_clkout3 clk200_clk} -group {eth_rx_clk eth_tx_clk}
+set_clock_groups -exclusive -group {clk100 soc_clk100bg soc_pll_fb} -group {soc_pll_sys sys_clk} -group {soc_pll_sys4x soc_pll_sys4x_dqs} -group {soc_pll_clk200 clk200_clk}

--- a/src/baselitex/baselitex_arty.v
+++ b/src/baselitex/baselitex_arty.v
@@ -37,6 +37,12 @@ module top(
 	output [3:0] led
 );
 
+`ifdef VIVADO
+`define PLL_PHASE 90
+`else
+`define PLL_PHASE 90000
+`endif
+
 wire [3:0] led;
 
 assign led[0] = idelayctl_rdy;
@@ -13398,7 +13404,7 @@ PLLE2_ADV #(
 	.CLKOUT1_DIVIDE(3'd5),
 	.CLKOUT1_PHASE(1'd0),
 	.CLKOUT2_DIVIDE(3'd5),
-	.CLKOUT2_PHASE(90000),
+	.CLKOUT2_PHASE(`PLL_PHASE),
 	.CLKOUT3_DIVIDE(3'd6),
 	.CLKOUT3_PHASE(1'd0),
 	.CLKOUT4_DIVIDE(6'd48),

--- a/src/baselitex/baselitex_arty.v
+++ b/src/baselitex/baselitex_arty.v
@@ -6268,8 +6268,6 @@ always @(*) begin
 		end
 	endcase
 end
-assign eth_rx_clk = eth_clocks_rx;
-assign eth_tx_clk = eth_clocks_tx;
 assign soc_reset0 = (soc_reset_storage | soc_reset1);
 assign eth_rst_n = (~soc_reset0);
 assign soc_counter_done = (soc_counter == 9'd256);
@@ -13452,6 +13450,16 @@ BUFG BUFG_4(
 BUFG BUFG_5(
 	.I(soc_pll_clk100),
 	.O(eth_ref_clk)
+);
+
+BUFG BUFG_6(
+	.I(eth_clocks_tx),
+	.O(eth_tx_clk)
+);
+
+BUFG BUFG_7(
+	.I(eth_clocks_rx),
+	.O(eth_rx_clk)
 );
 
 (* LOC="IDELAYCTRL_X1Y0" *)

--- a/src/baselitex/baselitex_arty.v
+++ b/src/baselitex/baselitex_arty.v
@@ -6268,6 +6268,8 @@ always @(*) begin
 		end
 	endcase
 end
+assign eth_rx_clk = eth_clocks_rx;
+assign eth_tx_clk = eth_clocks_tx;
 assign soc_reset0 = (soc_reset_storage | soc_reset1);
 assign eth_rst_n = (~soc_reset0);
 assign soc_counter_done = (soc_counter == 9'd256);
@@ -13422,8 +13424,11 @@ PLLE2_ADV #(
 	.LOCKED(soc_pll_locked)
 );
 
+wire clk100_ibuf;
+IBUF clkbuf(.I(clk100), .O(clk100_ibuf));
+
 BUFG BUFG(
-	.I(clk100),
+	.I(clk100_ibuf),
 	.O(soc_clk100bg)
 );
 
@@ -13449,18 +13454,11 @@ BUFG BUFG_4(
 
 BUFG BUFG_5(
 	.I(soc_pll_clk100),
-	.O(eth_ref_clk)
+	.O(eth_ref_clk_obuf)
 );
 
-BUFG BUFG_6(
-	.I(eth_clocks_tx),
-	.O(eth_tx_clk)
-);
-
-BUFG BUFG_7(
-	.I(eth_clocks_rx),
-	.O(eth_rx_clk)
-);
+wire eth_ref_clk_obuf;
+OBUF clk_eth_buf(.I(eth_ref_clk_obuf), .O(eth_ref_clk));
 
 (* LOC="IDELAYCTRL_X1Y0" *)
 IDELAYCTRL IDELAYCTRL(

--- a/src/baselitex/baselitex_arty_vivado.xdc
+++ b/src/baselitex/baselitex_arty_vivado.xdc
@@ -1,0 +1,308 @@
+set_property IS_ENABLED 0 [get_drc_checks {PDRC-26}]
+set_property LOC H5 [get_ports {led[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[0]}]
+set_property LOC J5 [get_ports {led[1]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[1]}]
+set_property LOC T9 [get_ports {led[2]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[2]}]
+set_property LOC T10 [get_ports {led[3]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[3]}]
+
+ ### serial:0.tx
+set_property LOC D10 [get_ports serial_tx]
+set_property IOSTANDARD LVCMOS33 [get_ports serial_tx]
+ ### serial:0.rx
+set_property LOC A9 [get_ports serial_rx]
+set_property IOSTANDARD LVCMOS33 [get_ports serial_rx]
+ ### clk100:0
+set_property LOC E3 [get_ports clk100]
+set_property IOSTANDARD LVCMOS33 [get_ports clk100]
+ ### eth_ref_clk:0
+set_property LOC G18 [get_ports eth_ref_clk]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_ref_clk]
+ ### cpu_reset:0
+set_property LOC C2 [get_ports cpu_reset]
+set_property IOSTANDARD LVCMOS33 [get_ports cpu_reset]
+ ### ddram:0.a
+set_property LOC R2 [get_ports {ddram_a[0]} ]
+set_property SLEW FAST [get_ports {ddram_a[0]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[0]} ]
+ ### ddram:0.a
+set_property LOC M6 [get_ports {ddram_a[1]} ]
+set_property SLEW FAST [get_ports {ddram_a[1]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[1]} ]
+ ### ddram:0.a
+set_property LOC N4 [get_ports {ddram_a[2]} ]
+set_property SLEW FAST [get_ports {ddram_a[2]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[2]} ]
+ ### ddram:0.a
+set_property LOC T1 [get_ports {ddram_a[3]} ]
+set_property SLEW FAST [get_ports {ddram_a[3]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[3]} ]
+ ### ddram:0.a
+set_property LOC N6 [get_ports {ddram_a[4]} ]
+set_property SLEW FAST [get_ports {ddram_a[4]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[4]} ]
+ ### ddram:0.a
+set_property LOC R7 [get_ports {ddram_a[5]} ]
+set_property SLEW FAST [get_ports {ddram_a[5]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[5]} ]
+ ### ddram:0.a
+set_property LOC V6 [get_ports {ddram_a[6]} ]
+set_property SLEW FAST [get_ports {ddram_a[6]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[6]} ]
+ ### ddram:0.a
+set_property LOC U7 [get_ports {ddram_a[7]} ]
+set_property SLEW FAST [get_ports {ddram_a[7]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[7]} ]
+ ### ddram:0.a
+set_property LOC R8 [get_ports {ddram_a[8]} ]
+set_property SLEW FAST [get_ports {ddram_a[8]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[8]} ]
+ ### ddram:0.a
+set_property LOC V7 [get_ports {ddram_a[9]} ]
+set_property SLEW FAST [get_ports {ddram_a[9]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[9]} ]
+ ### ddram:0.a
+set_property LOC R6 [get_ports {ddram_a[10]} ]
+set_property SLEW FAST [get_ports {ddram_a[10]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[10]} ]
+ ### ddram:0.a
+set_property LOC U6 [get_ports {ddram_a[11]} ]
+set_property SLEW FAST [get_ports {ddram_a[11]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[11]} ]
+ ### ddram:0.a
+set_property LOC T6 [get_ports {ddram_a[12]} ]
+set_property SLEW FAST [get_ports {ddram_a[12]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[12]} ]
+ ### ddram:0.a
+set_property LOC T8 [get_ports {ddram_a[13]} ]
+set_property SLEW FAST [get_ports {ddram_a[13]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_a[13]} ]
+ ### ddram:0.ba
+set_property LOC R1 [get_ports {ddram_ba[0]} ]
+set_property SLEW FAST [get_ports {ddram_ba[0]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_ba[0]} ]
+ ### ddram:0.ba
+set_property LOC P4 [get_ports {ddram_ba[1]} ]
+set_property SLEW FAST [get_ports {ddram_ba[1]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_ba[1]} ]
+ ### ddram:0.ba
+set_property LOC P2 [get_ports {ddram_ba[2]} ]
+set_property SLEW FAST [get_ports {ddram_ba[2]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_ba[2]} ]
+ ### ddram:0.ras_n
+set_property LOC P3 [get_ports ddram_ras_n]
+set_property SLEW FAST [get_ports ddram_ras_n]
+set_property IOSTANDARD SSTL135 [get_ports ddram_ras_n]
+ ### ddram:0.cas_n
+set_property LOC M4 [get_ports ddram_cas_n]
+set_property SLEW FAST [get_ports ddram_cas_n]
+set_property IOSTANDARD SSTL135 [get_ports ddram_cas_n]
+ ### ddram:0.we_n
+set_property LOC P5 [get_ports ddram_we_n]
+set_property SLEW FAST [get_ports ddram_we_n]
+set_property IOSTANDARD SSTL135 [get_ports ddram_we_n]
+ ### ddram:0.cs_n
+set_property LOC U8 [get_ports ddram_cs_n]
+set_property SLEW FAST [get_ports ddram_cs_n]
+set_property IOSTANDARD SSTL135 [get_ports ddram_cs_n]
+ ### ddram:0.dm
+set_property LOC L1 [get_ports {ddram_dm[0]} ]
+set_property SLEW FAST [get_ports {ddram_dm[0]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dm[0]} ]
+ ### ddram:0.dm
+set_property LOC U1 [get_ports {ddram_dm[1]} ]
+set_property SLEW FAST [get_ports {ddram_dm[1]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dm[1]} ]
+ ### ddram:0.dq
+set_property LOC K5 [get_ports {ddram_dq[0]} ]
+set_property SLEW FAST [get_ports {ddram_dq[0]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[0]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[0]} ]
+ ### ddram:0.dq
+set_property LOC L3 [get_ports {ddram_dq[1]} ]
+set_property SLEW FAST [get_ports {ddram_dq[1]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[1]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[1]} ]
+ ### ddram:0.dq
+set_property LOC K3 [get_ports {ddram_dq[2]} ]
+set_property SLEW FAST [get_ports {ddram_dq[2]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[2]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[2]} ]
+ ### ddram:0.dq
+set_property LOC L6 [get_ports {ddram_dq[3]} ]
+set_property SLEW FAST [get_ports {ddram_dq[3]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[3]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[3]} ]
+ ### ddram:0.dq
+set_property LOC M3 [get_ports {ddram_dq[4]} ]
+set_property SLEW FAST [get_ports {ddram_dq[4]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[4]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[4]} ]
+ ### ddram:0.dq
+set_property LOC M1 [get_ports {ddram_dq[5]} ]
+set_property SLEW FAST [get_ports {ddram_dq[5]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[5]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[5]} ]
+ ### ddram:0.dq
+set_property LOC L4 [get_ports {ddram_dq[6]} ]
+set_property SLEW FAST [get_ports {ddram_dq[6]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[6]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[6]} ]
+ ### ddram:0.dq
+set_property LOC M2 [get_ports {ddram_dq[7]} ]
+set_property SLEW FAST [get_ports {ddram_dq[7]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[7]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[7]} ]
+ ### ddram:0.dq
+set_property LOC V4 [get_ports {ddram_dq[8]} ]
+set_property SLEW FAST [get_ports {ddram_dq[8]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[8]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[8]} ]
+ ### ddram:0.dq
+set_property LOC T5 [get_ports {ddram_dq[9]} ]
+set_property SLEW FAST [get_ports {ddram_dq[9]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[9]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[9]} ]
+ ### ddram:0.dq
+set_property LOC U4 [get_ports {ddram_dq[10]} ]
+set_property SLEW FAST [get_ports {ddram_dq[10]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[10]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[10]} ]
+ ### ddram:0.dq
+set_property LOC V5 [get_ports {ddram_dq[11]} ]
+set_property SLEW FAST [get_ports {ddram_dq[11]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[11]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[11]} ]
+ ### ddram:0.dq
+set_property LOC V1 [get_ports {ddram_dq[12]} ]
+set_property SLEW FAST [get_ports {ddram_dq[12]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[12]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[12]} ]
+ ### ddram:0.dq
+set_property LOC T3 [get_ports {ddram_dq[13]} ]
+set_property SLEW FAST [get_ports {ddram_dq[13]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[13]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[13]} ]
+ ### ddram:0.dq
+set_property LOC U3 [get_ports {ddram_dq[14]} ]
+set_property SLEW FAST [get_ports {ddram_dq[14]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[14]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[14]} ]
+ ### ddram:0.dq
+set_property LOC R3 [get_ports {ddram_dq[15]} ]
+set_property SLEW FAST [get_ports {ddram_dq[15]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[15]} ]
+set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[15]} ]
+ ### ddram:0.dqs_p
+set_property LOC N2 [get_ports {ddram_dqs_p[0]} ]
+set_property SLEW FAST [get_ports {ddram_dqs_p[0]} ]
+set_property IOSTANDARD DIFF_SSTL135 [get_ports {ddram_dqs_p[0]} ]
+ ### ddram:0.dqs_p
+set_property LOC U2 [get_ports {ddram_dqs_p[1]} ]
+set_property SLEW FAST [get_ports {ddram_dqs_p[1]} ]
+set_property IOSTANDARD DIFF_SSTL135 [get_ports {ddram_dqs_p[1]} ]
+ ### ddram:0.dqs_n
+set_property LOC N1 [get_ports {ddram_dqs_n[0]} ]
+set_property SLEW FAST [get_ports {ddram_dqs_n[0]} ]
+set_property IOSTANDARD DIFF_SSTL135 [get_ports {ddram_dqs_n[0]} ]
+ ### ddram:0.dqs_n
+set_property LOC V2 [get_ports {ddram_dqs_n[1]} ]
+set_property SLEW FAST [get_ports {ddram_dqs_n[1]} ]
+set_property IOSTANDARD DIFF_SSTL135 [get_ports {ddram_dqs_n[1]} ]
+ ### ddram:0.clk_p
+set_property LOC U9 [get_ports ddram_clk_p]
+set_property SLEW FAST [get_ports ddram_clk_p]
+set_property IOSTANDARD DIFF_SSTL135 [get_ports ddram_clk_p]
+ ### ddram:0.clk_n
+set_property LOC V9 [get_ports ddram_clk_n]
+set_property SLEW FAST [get_ports ddram_clk_n]
+set_property IOSTANDARD DIFF_SSTL135 [get_ports ddram_clk_n]
+ ### ddram:0.cke
+set_property LOC N5 [get_ports ddram_cke]
+set_property SLEW FAST [get_ports ddram_cke]
+set_property IOSTANDARD SSTL135 [get_ports ddram_cke]
+ ### ddram:0.odt
+set_property LOC R5 [get_ports ddram_odt]
+set_property SLEW FAST [get_ports ddram_odt]
+set_property IOSTANDARD SSTL135 [get_ports ddram_odt]
+ ### ddram:0.reset_n
+set_property LOC K6 [get_ports ddram_reset_n]
+set_property SLEW FAST [get_ports ddram_reset_n]
+set_property IOSTANDARD SSTL135 [get_ports ddram_reset_n]
+
+set_property LOC H16 [get_ports eth_clocks_tx]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_clocks_tx]
+set_property LOC F15 [get_ports eth_clocks_rx]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_clocks_rx]
+ ## eth:0.rst_n
+set_property LOC C16 [get_ports eth_rst_n]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_rst_n]
+ ## eth:0.mdio
+set_property LOC K13 [get_ports eth_mdio]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_mdio]
+ ## eth:0.mdc
+set_property LOC F16 [get_ports eth_mdc]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_mdc]
+ ## eth:0.rx_dv
+set_property LOC G16 [get_ports eth_rx_dv]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_rx_dv]
+ ## eth:0.rx_er
+set_property LOC C17 [get_ports eth_rx_er]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_rx_er]
+ ## eth:0.rx_data
+set_property LOC D18 [get_ports {eth_rx_data[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {eth_rx_data[0]}]
+ ## eth:0.rx_data
+set_property LOC E17 [get_ports {eth_rx_data[1]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {eth_rx_data[1]}]
+ ## eth:0.rx_data
+set_property LOC E18 [get_ports {eth_rx_data[2]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {eth_rx_data[2]}]
+ ## eth:0.rx_data
+set_property LOC G17 [get_ports {eth_rx_data[3]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {eth_rx_data[3]}]
+ ## eth:0.tx_en
+set_property LOC H15 [get_ports eth_tx_en]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_tx_en]
+ ## eth:0.tx_data
+set_property LOC H14 [get_ports {eth_tx_data[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {eth_tx_data[0]}]
+ ## eth:0.tx_data
+set_property LOC J14 [get_ports {eth_tx_data[1]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {eth_tx_data[1]}]
+ ## eth:0.tx_data
+set_property LOC J13 [get_ports {eth_tx_data[2]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {eth_tx_data[2]}]
+ ## eth:0.tx_data
+set_property LOC H17 [get_ports {eth_tx_data[3]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {eth_tx_data[3]}]
+ ## eth:0.col
+set_property LOC D17 [get_ports eth_col]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_col]
+ ## eth:0.crs
+set_property LOC G14 [get_ports eth_crs]
+set_property IOSTANDARD LVCMOS33 [get_ports eth_crs]
+
+set_property INTERNAL_VREF 0.750 [get_iobanks 34]
+
+create_clock -name sys_clk -period 16.666 [get_nets sys_clk]
+
+create_clock -name clk100 -period 10.0 [get_nets clk100]
+
+create_clock -name eth_rx_clk -period 40.0 [get_nets eth_rx_clk]
+
+create_clock -name eth_tx_clk -period 40.0 [get_nets eth_tx_clk]
+
+set_clock_groups -group [get_clocks -include_generated_clocks -of [get_nets sys_clk]] -group [get_clocks -include_generated_clocks -of [get_nets eth_rx_clk]] -asynchronous
+
+set_clock_groups -group [get_clocks -include_generated_clocks -of [get_nets sys_clk]] -group [get_clocks -include_generated_clocks -of [get_nets eth_tx_clk]] -asynchronous
+
+set_clock_groups -group [get_clocks -include_generated_clocks -of [get_nets eth_rx_clk]] -group [get_clocks -include_generated_clocks -of [get_nets eth_tx_clk]] -asynchronous
+
+set_false_path -quiet -to [get_nets -quiet -filter {mr_ff == TRUE}]
+
+set_false_path -quiet -to [get_pins -quiet -filter {REF_PIN_NAME == PRE} -of [get_cells -quiet -filter {ars_ff1 == TRUE || ars_ff2 == TRUE}]]
+
+set_max_delay 2 -quiet -from [get_pins -quiet -filter {REF_PIN_NAME == Q} -of [get_cells -quiet -filter {ars_ff1 == TRUE}]] -to [get_pins -quiet -filter {REF_PIN_NAME == D} -of [get_cells -quiet -filter {ars_ff2 == TRUE}]]

--- a/symbiflow.py
+++ b/symbiflow.py
@@ -25,7 +25,7 @@ class VPR(Toolchain):
         self.files = []
 
     def run(self):
-        with Timed(self, 'bit-all'):
+        with Timed(self, 'prepare'):
             os.makedirs(self.out_dir, exist_ok=True)
 
             for f in self.srcs:
@@ -80,7 +80,18 @@ class VPR(Toolchain):
                 edam=self.edam, work_root=self.out_dir
             )
             self.backend.configure("")
-            self.backend.build()
+        with Timed(self, 'synthesis'):
+            self.backend.build_main(self.top + '.eblif')
+        with Timed(self, 'pack'):
+            self.backend.build_main(self.top + '.net')
+        with Timed(self, 'place'):
+            self.backend.build_main(self.top + '.place')
+        with Timed(self, 'route'):
+            self.backend.build_main(self.top + '.route')
+        with Timed(self, 'fasm'):
+            self.backend.build_main(self.top + '.fasm')
+        with Timed(self, 'bitstream'):
+            self.backend.build_main(self.top + '.bit')
 
     def max_freq(self):
 

--- a/symbiflow.py
+++ b/symbiflow.py
@@ -177,8 +177,10 @@ class VPR(Toolchain):
             iob = iob + res['outpad']
         if 'inpad' in res:
             iob = iob + res['inpad']
-        if 'BRAM' in res:
-            bram = res['BRAM']
+        if 'RAMB18E1_Y0' in res:
+            bram += res['RAMB18E1_Y0']
+        if 'RAMB18E1_Y1' in res:
+            bram += res['RAMB18E1_Y1']
         if 'PLLE2_ADV' in res:
             pll = res['PLLE2_ADV']
 

--- a/symbiflow.py
+++ b/symbiflow.py
@@ -83,52 +83,28 @@ class VPR(Toolchain):
             self.backend.build()
 
     def max_freq(self):
-        # FIXME
-        return 0.0
 
-    """
-    @staticmethod
-    def resource_parse(f):
-        '''
-        abanonded in favor of icebox_stat
-        although maybe would be good to compare results?
+        freqs = {}
+        route_log = self.out_dir + '/route.log'
+        processing = False
 
-        Resource usage...
-            Netlist      0    blocks of type: EMPTY
-            Architecture 0    blocks of type: EMPTY
-            Netlist      4    blocks of type: BLK_TL-PLB
-            Architecture 960    blocks of type: BLK_TL-PLB
-            Netlist      0    blocks of type: BLK_TL-RAM
-            Architecture 32    blocks of type: BLK_TL-RAM
-            Netlist      2    blocks of type: BLK_TL-PIO
-            Architecture 256    blocks of type: BLK_TL-PIO
+        with open(route_log, 'r') as fp:
+            for l in fp:
 
-        Device Utilization: 0.00 (target 1.00)
-            Block Utilization: 0.00 Type: EMPTY
-            Block Utilization: 0.00 Type: BLK_TL-PLB
-            Block Utilization: 0.00 Type: BLK_TL-RAM
-            Block Utilization: 0.01 Type: BLK_TL-PIO
-        '''
-        def waitfor(s):
-            while True:
-                l = f.readline()
-                if not l:
-                    raise Exception("EOF")
-                if s.find(s) >= 0:
-                    return
-        waitfor('Resource usage...')
-        while True:
-            l = f.readline().strip()
-            if not l:
-                break
-            # Netlist      2    blocks of type: BLK_TL-PIO
-            # Architecture 256    blocks of type: BLK_TL-PIO
-            parts = l.split()
-            if parts[0] != 'Netlist':
-                continue
+                if l == "Intra-domain critical path delays (CPDs):\n":
+                    processing = True
+                    continue
 
-        waitfor('Device Utilization: ')
-    """
+                if processing is True:
+                    if len(l.strip('\n')) == 0:
+                        processing = False
+                        continue
+
+                    fields = l.split(':')
+                    group = fields[0].split()[0]
+                    freqs[group] = 1e9 / float(fields[1].split()[0].strip())
+
+        return freqs
 
     def get_vpr_resources(self):
         """

--- a/toolchain.py
+++ b/toolchain.py
@@ -247,35 +247,6 @@ class Toolchain:
         with open(out_dir + '/meta.json', 'w') as f:
             json.dump(j, f, sort_keys=True, indent=4)
 
-        # write .csv for easy import
-        with open(out_dir + '/meta.csv', 'w') as csv:
-            nonestr = lambda x: x if x is not None else ''
-
-            csv.write(
-                'Build,Date,Family,Device,Package,Project,Toolchain,Strategy,pcf,sdc,xdc,Carry,Seed,Freq (MHz),Build (sec),#LUT,#DFF,#BRAM,#CARRY,#GLB,#PLL,#IOB\n'
-            )
-            pcf_str = os.path.basename(self.pcf) if self.pcf else ''
-            sdc_str = os.path.basename(self.sdc) if self.sdc else ''
-            xdc_str = os.path.basename(self.xdc) if self.xdc else ''
-            seed_str = '%08X' % self.seed if self.seed else ''
-            runtime_str = '%0.1f' % self.runtimes[
-                'bit-all'] if 'bit-all' in self.runtimes else ''
-            freq_str = '%0.1f' % (
-                max_freq / 1e6
-            ) if max_freq is not None else ''
-            fields = [
-                nonestr(self.build), date_str, self.family, self.device,
-                self.package, self.project_name, self.toolchain,
-                nonestr(self.strategy), pcf_str, sdc_str, xdc_str,
-                str(self.carry), seed_str, freq_str, runtime_str
-            ]
-            fields += [
-                str(resources[x])
-                for x in ('LUT', 'DFF', 'BRAM', 'CARRY', 'GLB', 'PLL', 'IOB')
-            ]
-            csv.write(','.join(fields) + '\n')
-            csv.close()
-
         # Provide some context when comparing runtimes against systems
         subprocess.check_call(
             'uname -a >uname.txt',

--- a/toolchain.py
+++ b/toolchain.py
@@ -74,8 +74,16 @@ class Toolchain:
             add('seed-%08X' % (self.seed, ))
         return ret
 
-    def add_runtime(self, name, dt):
-        self.runtimes[name] = dt
+    def add_runtime(self, name, dt, parent=None):
+        if parent is None:
+            self.runtimes[name] = dt
+        else:
+            assert (parent not in self.runtimes) or (
+                type(self.runtimes[parent]) is collections.OrderedDict
+            )
+            if parent not in self.runtimes:
+                self.runtimes[parent] = collections.OrderedDict()
+            self.runtimes[parent][name] = dt
 
     def design(self):
         ret = self.family + '-' + self.device + '-' + self.package + '_' + self.toolchain + '_' + self.project_name

--- a/vivado.py
+++ b/vivado.py
@@ -51,13 +51,15 @@ class Vivado(Toolchain):
                 'files': self.files,
                 'name': self.project_name,
                 'toplevel': self.top,
-                'parameters' : {
-                    'VIVADO' : {
-                        'paramtype' : 'vlogdefine',
-                        'datatype' : 'int',
-                        'default' : 1,
+                'parameters':
+                    {
+                        'VIVADO':
+                            {
+                                'paramtype': 'vlogdefine',
+                                'datatype': 'int',
+                                'default': 1,
+                            },
                     },
-                },
                 'tool_options':
                     {
                         'vivado': {

--- a/vivado.py
+++ b/vivado.py
@@ -147,7 +147,10 @@ class Vivado(Toolchain):
                         # check if this is a timing we want
                         if group not in requirement.split():
                             continue
-                        freqs[group] = freq
+                        freqs[group] = dict()
+                        freqs[group]['actual'] = freq
+                        freqs[group]['requested'] = requested_freq
+                        freqs[group]['met'] = freq >= requested_freq
 
                     data = l.split(':')
                     if len(data) > 1:
@@ -158,6 +161,9 @@ class Vivado(Toolchain):
                             group = data[1].strip()
                         if data[0].strip() == 'Requirement':
                             requirement = data[1].strip()
+                            requested_freq = 1e9 / float(
+                                requirement.split()[0].strip('ns')
+                            )
 
         return freqs
 

--- a/vivado.py
+++ b/vivado.py
@@ -171,7 +171,8 @@ class Vivado(Toolchain):
             if prim[2] == 'CarryLogic':
                 carry += int(prim[1])
             if prim[2] == 'IO':
-                iob += int(prim[1])
+                if prim[0].startswith('OBUF') or prim[0].startswith('IBUF'):
+                    iob += int(prim[1])
             if prim[2] == 'LUT':
                 lut += int(prim[1])
 

--- a/vivado.py
+++ b/vivado.py
@@ -124,15 +124,13 @@ class Vivado(Toolchain):
             'vivado': have_exec('vivado'),
         }
 
-    def max_freq(self):
+    def get_max_freq(self, report_file):
         processing = False
 
         group = ""
         delay = ""
         freq = 0
         freqs = {}
-
-        report_file = self.out_dir + "/" + self.project_name + ".runs/impl_1/top_timing_summary_routed.rpt"
         path_type = None
 
         with open(report_file, 'r') as fp:
@@ -185,6 +183,10 @@ class Vivado(Toolchain):
                             if path_type != ptype.split()[0]:
                                 path_type = ptype.split()[0]
         return freqs
+
+    def max_freq(self):
+        report_file = self.out_dir + "/" + self.project_name + '.runs/impl_1/top_timing_summary_routed.rpt'
+        return self.get_max_freq(report_file)
 
     def vivado_resources(self, report_file):
         with open(report_file, 'r') as fp:
@@ -283,6 +285,10 @@ class VivadoYosys(Vivado):
     def resources(self):
         report_file = self.out_dir + "/top_utilization_placed.rpt"
         return super(VivadoYosys, self).resources(report_file)
+
+    def max_freq(self):
+        report_file = self.out_dir + "/top_timing_summary_routed.rpt"
+        return super(VivadoYosys, self).get_max_freq(report_file)
 
     def versions(self):
         return {

--- a/vivado.py
+++ b/vivado.py
@@ -51,6 +51,13 @@ class Vivado(Toolchain):
                 'files': self.files,
                 'name': self.project_name,
                 'toplevel': self.top,
+                'parameters' : {
+                    'VIVADO' : {
+                        'paramtype' : 'vlogdefine',
+                        'datatype' : 'int',
+                        'default' : 1,
+                    },
+                },
                 'tool_options':
                     {
                         'vivado': {

--- a/vivado.py
+++ b/vivado.py
@@ -182,7 +182,8 @@ class Vivado(Toolchain):
 
         for prim in report['memory']:
             if prim[0] == 'Block RAM Tile':
-                bram += prim[1]
+                # Vivado reports RAMB36. Multiply it by 2 to get RAMB18
+                bram += prim[1] * 2
 
         ret = {
             "LUT": str(lut),


### PR DESCRIPTION
This PR adds timing results extraction for Vivado and Symbiflow toolchains.

Bellow, are example results for litex-linux test:
Vivado:
command:
```
python3 fpgaperf.py --toolchain vivado --project litex-linux --family "xc7" --device "a35ti" --package "csg324-1L" --pcf src/baselitex/baselitex_arty_vivado.xdc
```
results:
```
  Family: xc7
  Device: a35ti
  Package: csg324-1L
  Project: litex-linux
  Toolchain: vivado
  Strategy: None
  Carry: False
  Seed: default
Timing:
  nop:             0.007
  bitstream:       178.580
Max frequency in clock domain soc_pll_clk200 849.618 MHz
Max frequency in clock domain eth_rx_clk 122.175 MHz
Max frequency in clock domain eth_tx_clk 107.021 MHz
Max frequency in clock domain sys_clk 87.835 MHz
Resource utilization
  BRAM:                81.0
  CARRY:               260
  DFF:                 4883
  IOB:                 89
  LUT:                 6207
  PLL:                 1
```
Symbiflow (Yosys + VPR):
command:
```
python3 fpgaperf.py --toolchain vpr --project litex-linux --family "xc7" --device "a35t" --package "csg324-1" --pcf src/baselitex/arty.pcf --sdc src/baselitex/arty.sdc --xdc src/baselitex/baselitex_arty.xdc 
```
results:
```
  Family: xc7
  Device: a35t
  Package: csg324-1
  Project: litex-linux
  Toolchain: vpr
  Strategy: None
  Carry: False
  Seed: default
Timing:
  nop:             0.006
  bit-all:         812.225
Max frequency in clock domain sys_clk__VexRiscv.IBusCachedPlugin_cache.clk__VexRiscv.clk__VexRiscv.dataCache_1_.clk 50.989 MHz
Max frequency in clock domain clk200_clk 219.449 MHz
Max frequency in clock domain eth_tx_clk 53.296 MHz
Max frequency in clock domain eth_rx_clk 67.444 MHz
Resource utilization
  BRAM:                43
  CARRY:               325
  DFF:                 3832
  IOB:                 89
  LUT:                 10932
  PLL:                 1
```
