### PR TITLE
Adding .gitattributes to import GitHub language stats.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Settings to improve linguist data reporting (used by GitHub)
+*.v 			linguist-language=Verilog
+*.vh 			linguist-language=Verilog
+*.pv 			linguist-language=Verilog
+
+src/**	  		linguist-vendored


### PR DESCRIPTION
#### Before
```
76.28%  Coq
18.57%  Verilog
3.58%   Python
1.57%   Shell
0.01%   Makefile

Makefile:
Makefile

Shell:
csv.sh
exhaust.sh
icecubed.sh
jenkins.sh
pcf_test.sh
radiant.sh
vpr_xml.sh
wrappers.sh

Python:
fpgaperf.py
icestorm.py
sow.py
symbiflow.py
test/test_all.py
toolchain.py
utils.py
vivado.py
wrapper.py

Coq:
src/baselitex/VexRiscv_Linux.v
src/baselitex/baselitex_arty.v
src/murax/Murax.v
src/picorv32_def.v

Verilog:
src/ibex/clkgen_xil7series.v
src/ibex/ibex_alu.v
src/ibex/ibex_compressed_decoder.v
src/ibex/ibex_controller.v
src/ibex/ibex_core.v
src/ibex/ibex_core_tracing.v
src/ibex/ibex_cs_registers.v
...
```
#### After
```
69.46%  Python
30.44%  Shell
0.10%   Makefile

Makefile:
Makefile

Shell:
csv.sh
exhaust.sh
icecubed.sh
jenkins.sh
pcf_test.sh
radiant.sh
vpr_xml.sh
wrappers.sh

Python:
fpgaperf.py
icestorm.py
sow.py
symbiflow.py
test/test_all.py
toolchain.py
utils.py
vivado.py
wrapper.py
```