### PR TITLE
Custom parameter injection and multiple tests run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,13 @@ conda:
 	cd third_party/prjxray && $(MAKE) build -j`nproc`
 
 run-all:
-	python3 exhaust.py --fail
+	python3 exhaust.py
+	# TMP: Testing multiple options
+	python3 exhaust.py --parameters parameters.json --toolchain vpr --build_type parameters --project blinky
+	# TMP: Testing multiple builds
+	for run in {1..10}; do \
+		python3 exhaust.py --toolchain vpr --project blinky --build_type multiple-samples --build $$run; \
+	done
 
 PYTHON_SRCS=$(shell find . -name "*py" -not -path "./third_party/*" -not -path "./env/*")
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ conda:
 	cd third_party/prjxray && $(MAKE) build -j`nproc`
 
 run-tests:
-	python3 exhaust.py --build_type generic
+	python3 exhaust.py --build_type generic --fail
 
 run-parameters-tests:
 	python3 exhaust.py --parameters parameters.json --toolchain vpr --build_type parameters

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ conda:
 	cd third_party/prjxray && $(MAKE) build -j`nproc`
 
 run-all:
-	python3 exhaust.py
+	python3 exhaust.py --fail
 
 PYTHON_SRCS=$(shell find . -name "*py" -not -path "./third_party/*" -not -path "./env/*")
 

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,21 @@ conda:
 	rm ${SYMBIFLOW_ARCHIVE}
 	cd third_party/prjxray && $(MAKE) build -j`nproc`
 
-run-all:
-	python3 exhaust.py
-	# TMP: Testing multiple options
-	python3 exhaust.py --parameters parameters.json --toolchain vpr --build_type parameters --project blinky
-	# TMP: Testing multiple builds
-	for run in {1..10}; do \
-		python3 exhaust.py --toolchain vpr --project blinky --build_type multiple-samples --build $$run; \
+run-tests:
+	python3 exhaust.py --build_type generic
+
+run-parameters-tests:
+	python3 exhaust.py --parameters parameters.json --toolchain vpr --build_type parameters
+
+run-multiple-samples-tests:
+	for run in {0..10}; do \
+		python3 exhaust.py --build_type multiple-samples --build $$run; \
 	done
+
+run-all:
+	$(MAKE) run-tests
+	$(MAKE) run-parameters-tests
+	$(MAKE) run-multiple-samples-tests
 
 PYTHON_SRCS=$(shell find . -name "*py" -not -path "./third_party/*" -not -path "./env/*")
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SHELL = bash
 PWD = $(shell pwd)
 INSTALL_DIR = ${PWD}/third_party/install
 
+MULTIPLE_RUN_ITERATIONS ?= 2
+
 SYMBIFLOW_ARCHIVE = symbiflow.tar.xz
 # FIXME: make this dynamic: https://github.com/SymbiFlow/fpga-tool-perf/issues/75
 SYMBIFLOW_URL = "https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/6/20200504-160845/symbiflow-arch-defs-install-3f537c97.tar.xz"
@@ -25,8 +27,8 @@ run-parameters-tests:
 	python3 exhaust.py --parameters parameters.json --toolchain vpr --build_type parameters
 
 run-multiple-samples-tests:
-	for run in {0..10}; do \
-		python3 exhaust.py --build_type multiple-samples --build $$run; \
+	for run in {0..${MULTIPLE_RUN_ITERATIONS}}; do \
+		python3 exhaust.py --project blinky --toolchain vpr --build_type multiple-samples --build $$run; \
 	done
 
 run-all:

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - yosys
   - yosys-plugins
-  - vtr
+  - vtr=8.0.0.rc2_3864_g0ece2d2c1
   - nextpnr-xilinx
   - pip
   - pip:                            # Packages installed from PyPI

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - yosys
   - yosys-plugins
   - vtr=8.0.0.rc2_3864_g0ece2d2c1
-  - nextpnr-xilinx
+  - nextpnr-xilinx=0.0_2803_gda2b6c81
   - pip
   - pip:                            # Packages installed from PyPI
     - -r file:requirements.txt

--- a/dataframe.py
+++ b/dataframe.py
@@ -80,7 +80,7 @@ def get_general_dataframe(results):
             resources = {k: [] for k in resource.keys()}
 
         for k, v in resource.items():
-            resources[k].append(v)
+            resources[k].append(int(v))
 
     resources_keys = list(resources.keys())
     for key in resources_keys:

--- a/dataframe.py
+++ b/dataframe.py
@@ -80,7 +80,8 @@ def get_general_dataframe(results):
             resources = {k: [] for k in resource.keys()}
 
         for k, v in resource.items():
-            resources[k].append(int(v))
+            value = int(float(v)) if v else None
+            resources[k].append(value)
 
     resources_keys = list(resources.keys())
     for key in resources_keys:

--- a/exhaust.py
+++ b/exhaust.py
@@ -125,6 +125,7 @@ def main():
     params_file = args.parameters
     params_strings = [None]
     if params_file:
+        params_strings = []
         assert len(
             args.toolchain
         ) == 1, "A single toolchain can be selected when running multiple params."

--- a/exhaust.py
+++ b/exhaust.py
@@ -19,6 +19,7 @@ from runner import Runner
 root_dir = os.path.dirname(os.path.abspath(__file__))
 src_dir = root_dir + '/src'
 
+
 def get_reports(out_prefix):
     """Returns all the reports from all the build runs."""
     return matching_pattern(
@@ -41,7 +42,10 @@ def print_summary_table(out_prefix, total_tasks):
     """Prints a summary table of the outcome of each test."""
     builds = get_builds(out_prefix)
     table_data = [
-        ['Project', 'Toolchain', 'Family', 'Part', 'Board', 'Build N.', 'Options']
+        [
+            'Project', 'Toolchain', 'Family', 'Part', 'Board', 'Build N.',
+            'Options'
+        ]
     ]
     passed = failed = 0
     for build in sorted(builds):
@@ -104,10 +108,7 @@ def main():
 
     tasks = Tasks(src_dir)
 
-    args_dict = {
-            "project": args.project,
-            "toolchain": args.toolchain
-            }
+    args_dict = {"project": args.project, "toolchain": args.toolchain}
 
     task_list = tasks.get_tasks(args_dict)
 

--- a/exhaust.py
+++ b/exhaust.py
@@ -7,24 +7,13 @@ import time
 import re
 from terminaltables import AsciiTable
 from colorclass import Color
-from itertools import product
 
-from fpgaperf import run, matching_pattern
-import sow
-import pandas
-from dataframe import generate_dataframe
 from tasks import Tasks
 from runner import Runner
+from tool_parameters import ToolParametersHelper
 
 root_dir = os.path.dirname(os.path.abspath(__file__))
 src_dir = root_dir + '/src'
-
-
-def get_reports(out_prefix):
-    """Returns all the reports from all the build runs."""
-    return matching_pattern(
-        os.path.join(root_dir, out_prefix, '*/meta.json'), '(.*)'
-    )
 
 
 def get_builds(out_prefix):
@@ -38,21 +27,30 @@ def get_builds(out_prefix):
     return builds
 
 
-def print_summary_table(out_prefix, total_tasks):
+def print_summary_table(out_prefix, build_type, build_nr=None):
     """Prints a summary table of the outcome of each test."""
     builds = get_builds(out_prefix)
     table_data = [
         [
-            'Project', 'Toolchain', 'Family', 'Part', 'Board', 'Build N.',
-            'Options'
+            'Project', 'Toolchain', 'Family', 'Part', 'Board', 'Build Type',
+            'Build N.', 'Options'
         ]
     ]
     passed = failed = 0
+    build_count = 0
     for build in sorted(builds):
         # Split directory name into columns
-        # Example: oneblink_vpr_xc7_a35tcsg326-1_arty_options
-        pattern = '([^_]*)_([^_]*)_([^_]*)_([^_]*)_([^_]*)_([^_]*)_(.*)'
+        # Example: oneblink_vpr_xc7_a35tcsg326-1_arty_generic-build_0_options
+        pattern = ''
+        for i in range(0, len(table_data[0]) - 1):
+            pattern += '([^_]*)_'
+        pattern += '(.*)'
+
         row = list(re.match(pattern, build).groups())
+
+        if build_type != row[5] or (build_nr and int(build_nr) != int(row[6])):
+            continue
+
         # Check if metadata was generated
         # It is created for successful builds only
         if os.path.exists(os.path.join(root_dir, out_prefix, build,
@@ -63,12 +61,13 @@ def print_summary_table(out_prefix, total_tasks):
             row.append(Color('{autored}failed{/autored}'))
             failed += 1
         table_data.append(row)
+        build_count += 1
 
     table_data.append(
         [
             Color('{autogreen}Passed:{/autogreen}'), passed,
-            Color('{autored}Failed:{/autored}'), failed, '', '',
-            '{}%'.format(int(passed / total_tasks * 100))
+            Color('{autored}Failed:{/autored}'), failed, '', '', '', '',
+            '{}%'.format(int(passed / build_count * 100))
         ]
     )
     table = AsciiTable(table_data)
@@ -100,10 +99,21 @@ def main():
         default='build',
         help='output directory prefix (default: build)'
     )
+    parser.add_argument(
+        '--build_type',
+        default='generic',
+        help=
+        'Type of build that is performed (e.g. regression test, multiple options, etc.)'
+    )
+    parser.add_argument('--build', default=None, help='Build number')
+    parser.add_argument(
+        '--parameters', default=None, help='Tool parameters json file'
+    )
     parser.add_argument('--fail', action='store_true', help='fail on error')
     parser.add_argument(
         '--verbose', action='store_true', help='verbose output'
     )
+
     args = parser.parse_args()
 
     tasks = Tasks(src_dir)
@@ -112,24 +122,25 @@ def main():
 
     task_list = tasks.get_tasks(args_dict)
 
-    runner = Runner(task_list, args.verbose, args.out_prefix)
+    params_file = args.parameters
+    params_strings = [None]
+    if params_file:
+        assert len(
+            args.toolchain
+        ) == 1, "A single toolchain can be selected when running multiple params."
+
+        params_helper = ToolParametersHelper(args.toolchain[0], params_file)
+        for params in params_helper.get_all_params_combinations():
+            params_strings.append(" ".join(params))
+
+    runner = Runner(
+        task_list, args.verbose, args.out_prefix, root_dir, args.build_type,
+        args.build, params_strings
+    )
     runner.run()
+    runner.collect_results()
 
-    # Combine results of all tests
-    print('Merging results')
-    merged_dict = {}
-
-    for report in get_reports(args.out_prefix):
-        sow.merge(merged_dict, json.load(open(report, 'r')))
-
-    with open('{}/all.json'.format(args.out_prefix), 'w') as fout:
-        json.dump(merged_dict, fout, indent=4, sort_keys=True)
-
-    dataframe = generate_dataframe(merged_dict)
-    dataframe = dataframe.reset_index(drop=True)
-    dataframe.to_json('{}/dataframe.json'.format(args.out_prefix))
-
-    result = print_summary_table(args.out_prefix, len(task_list))
+    result = print_summary_table(args.out_prefix, args.build_type, args.build)
 
     if not result and args.fail:
         print("ERROR: some tests have failed.")

--- a/exhaust.py
+++ b/exhaust.py
@@ -94,10 +94,6 @@ def get_device_info(constraint):
     return full_info.split('_')
 
 
-def user_selected(option):
-    return [option] if option else None
-
-
 def iter_options(args):
     """Returns all the possible combination of:
         - projects,
@@ -112,8 +108,8 @@ def iter_options(args):
     - valid combination: src/oneblink/vpr/xc7_a35t_csg324-1_arty.pcf
     """
 
-    projects = user_selected(args.project) or get_projects()
-    toolchains = user_selected(args.toolchain) or get_toolchains()
+    projects = args.project or get_projects()
+    toolchains = args.toolchain or get_toolchains()
 
     combinations = set()
     for project, toolchain in list(product(projects, toolchains)):
@@ -145,6 +141,10 @@ def worker(arglist):
     out_prefix, verbose, project, family, device, package, board, toolchain = arglist
     # We don't want output of all subprocesses here
     # Log files for each build will be placed in build directory
+
+    #TMP
+    options = "--max_router_iterations 500 --routing_failure_predictor off --router_high_fanout_threshold -1 --constant_net_method route --route_chan_width 500       --router_heap bucket       --clock_modeling route       --place_delta_delay_matrix_calculation_method dijkstra       --place_delay_model delta_override       --router_lookahead connection_box_map       --quick_check_route on       --strict_checks off       --allow_dangling_combinational_nodes on       --disable_errors check_unbuffered_edges:check_route       --congested_routing_iteration_threshold 0.8       --incremental_reroute_delay_ripup off       --base_cost_type delay_normalized_length_bounded       --bb_factor 10       --initial_pres_fac 4.0       --check_rr_graph off"
+
     with redirect_stdout(open(os.devnull, 'w')):
         try:
             run(
@@ -154,6 +154,7 @@ def worker(arglist):
                 board,
                 toolchain,
                 project,
+                options,
                 None,  #out_dir
                 out_prefix,
                 None,  #strategy
@@ -195,11 +196,13 @@ def main():
     parser.add_argument(
         '--project',
         default=None,
+        nargs="+",
         help='run given project only (default: all)'
     )
     parser.add_argument(
         '--toolchain',
         default=None,
+        nargs="+",
         help='run given toolchain only (default: all)'
     )
     parser.add_argument(

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -166,7 +166,8 @@ def run(
     strategy=None,
     seed=None,
     carry=None,
-    build=None
+    build=None,
+    build_type=None,
 ):
     assert family == 'ice40' or family == 'xc7'
     assert device is not None
@@ -193,6 +194,7 @@ def run(
     t.sdc = os.path.realpath(sdc) if sdc else None
     t.xdc = os.path.realpath(xdc) if xdc else None
     t.build = build
+    t.build_type = build_type
 
     t.project(
         get_project(project),
@@ -376,6 +378,7 @@ def main():
         help='Auto named directory prefix (default: build)'
     )
     parser.add_argument('--build', default=None, help='Build number')
+    parser.add_argument('--build_type', default=None, help='Build type')
     args = parser.parse_args()
 
     assert not (args.params_file and args.params_string)
@@ -421,11 +424,12 @@ def main():
             params_string=args.params_string,
             out_dir=args.out_dir,
             out_prefix=args.out_prefix,
+            verbose=args.verbose,
             strategy=args.strategy,
             carry=args.carry,
             seed=seed,
             build=args.build,
-            verbose=args.verbose
+            build_type=args.build_type
         )
 
 

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -158,6 +158,8 @@ def run(
     board,
     toolchain,
     project,
+    params_file=None,
+    params_string=None,
     out_dir=None,
     out_prefix=None,
     verbose=False,
@@ -198,6 +200,8 @@ def run(
         device,
         package,
         board,
+        params_file,
+        params_string,
         out_dir=out_dir,
         out_prefix=out_prefix,
     )
@@ -332,6 +336,10 @@ def main():
     parser.add_argument('--package', default=None, help='FPGA Package')
     parser.add_argument('--board', default=None, help='Target board')
     parser.add_argument(
+        '--params_file', default=None, help='Use custom tool parameters')
+    parser.add_argument(
+        '--params_string', default=None, help='Use custom tool parameters')
+    parser.add_argument(
         '--strategy', default=None, help='Optimization strategy'
     )
     add_bool_arg(
@@ -367,6 +375,8 @@ def main():
     )
     parser.add_argument('--build', default=None, help='Build number')
     args = parser.parse_args()
+
+    assert not (args.params_file and args.params_string)
 
     if args.list_toolchains:
         list_toolchains()
@@ -405,6 +415,8 @@ def main():
             args.board,
             args.toolchain,
             args.project,
+            params_file=args.params_file,
+            params_string=args.params_string,
             out_dir=args.out_dir,
             out_prefix=args.out_prefix,
             strategy=args.strategy,

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -336,9 +336,11 @@ def main():
     parser.add_argument('--package', default=None, help='FPGA Package')
     parser.add_argument('--board', default=None, help='Target board')
     parser.add_argument(
-        '--params_file', default=None, help='Use custom tool parameters')
+        '--params_file', default=None, help='Use custom tool parameters'
+    )
     parser.add_argument(
-        '--params_string', default=None, help='Use custom tool parameters')
+        '--params_string', default=None, help='Use custom tool parameters'
+    )
     parser.add_argument(
         '--strategy', default=None, help='Optimization strategy'
     )

--- a/runner.py
+++ b/runner.py
@@ -22,7 +22,6 @@ class Runner:
     """Class to create a runner object that, given a list of tasks
     runs all of them parallely.
     """
-
     def __init__(self, task_list, verbose, out_prefix, options=[None]):
         self.verbose = verbose
         self.out_prefix = out_prefix
@@ -46,7 +45,6 @@ class Runner:
 
         This takes, as argument list, the various tasks to perform.
         """
-
         def eprint(*args, **kwargs):
             print(*args, file=sys.stderr, **kwargs)
 

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import tqdm
+from multiprocessing import Pool, cpu_count
+from contextlib import redirect_stdout
+
+from fpgaperf import run
+
+class Runner:
+
+    def __init__(self, task_list, verbose, out_prefix, options=[None]):
+        self.verbose = verbose
+        self.out_prefix = out_prefix
+
+        def add_tuple_to_tasks(tasks, tpl):
+            new_tasks = []
+
+            for task in tasks:
+                new_tasks.append(task + tpl)
+
+            return new_tasks
+
+        self.task_list = []
+        for idx, option in enumerate(options):
+            self.task_list += add_tuple_to_tasks(task_list, (option, "{:03d}".format(idx)))
+
+    def worker(self, arglist):
+        def eprint(*args, **kwargs):
+            print(*args, file=sys.stderr, **kwargs)
+
+        project, toolchain, family, device, package, board, option, build = arglist
+
+        # We don't want output of all subprocesses here
+        # Log files for each build will be placed in build directory
+        with redirect_stdout(open(os.devnull, 'w')):
+            try:
+                run(
+                    family,
+                    device,
+                    package,
+                    board,
+                    toolchain,
+                    project,
+                    None,  #options_file
+                    option,
+                    None,  #out_dir
+                    self.out_prefix,
+                    self.verbose,
+                    None,  #strategy
+                    None,  #seed
+                    None,  #carry
+                    build,
+                )
+            except Exception as e:
+                eprint("\n---------------------")
+                eprint(
+                    "ERROR: {} {} {}{}{} {} test has failed\n".format(
+                        project, toolchain, family, device, package, board
+                    )
+                )
+                eprint("ERROR MESSAGE: ", e)
+                eprint("---------------------\n")
+
+    def run(self):
+        if not os.path.exists(self.out_prefix):
+            os.mkdir(self.out_prefix)
+
+        with Pool(cpu_count()) as pool:
+            for _ in tqdm.tqdm(pool.imap_unordered(self.worker, self.task_list),
+                               total=len(self.task_list), unit='test'):
+                pass

--- a/runner.py
+++ b/runner.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
 import os
 import sys
 import tqdm
@@ -8,6 +19,10 @@ from fpgaperf import run
 
 
 class Runner:
+    """Class to create a runner object that, given a list of tasks
+    runs all of them parallely.
+    """
+
     def __init__(self, task_list, verbose, out_prefix, options=[None]):
         self.verbose = verbose
         self.out_prefix = out_prefix
@@ -27,6 +42,11 @@ class Runner:
             )
 
     def worker(self, arglist):
+        """Single worker function that is run in the Pool of workers.
+
+        This takes, as argument list, the various tasks to perform.
+        """
+
         def eprint(*args, **kwargs):
             print(*args, file=sys.stderr, **kwargs)
 

--- a/runner.py
+++ b/runner.py
@@ -6,8 +6,8 @@ from contextlib import redirect_stdout
 
 from fpgaperf import run
 
-class Runner:
 
+class Runner:
     def __init__(self, task_list, verbose, out_prefix, options=[None]):
         self.verbose = verbose
         self.out_prefix = out_prefix
@@ -22,7 +22,9 @@ class Runner:
 
         self.task_list = []
         for idx, option in enumerate(options):
-            self.task_list += add_tuple_to_tasks(task_list, (option, "{:03d}".format(idx)))
+            self.task_list += add_tuple_to_tasks(
+                task_list, (option, "{:03d}".format(idx))
+            )
 
     def worker(self, arglist):
         def eprint(*args, **kwargs):
@@ -66,6 +68,7 @@ class Runner:
             os.mkdir(self.out_prefix)
 
         with Pool(cpu_count()) as pool:
-            for _ in tqdm.tqdm(pool.imap_unordered(self.worker, self.task_list),
+            for _ in tqdm.tqdm(pool.imap_unordered(self.worker,
+                                                   self.task_list),
                                total=len(self.task_list), unit='test'):
                 pass

--- a/symbiflow.py
+++ b/symbiflow.py
@@ -92,7 +92,7 @@ class VPR(Toolchain):
 
     def get_tool_params(self):
         if self.params_file:
-            opt_helper = ToolParametersHelper('vpr', '--', self.params_file)
+            opt_helper = ToolParametersHelper('vpr', self.params_file)
             params = opt_helper.get_all_params_combinations()
 
             assert len(params) == 1

--- a/symbiflow.py
+++ b/symbiflow.py
@@ -4,6 +4,7 @@ import edalize
 
 from toolchain import Toolchain
 from utils import Timed
+from tool_parameters import ToolParametersHelper
 
 
 class VPR(Toolchain):
@@ -53,6 +54,8 @@ class VPR(Toolchain):
 
                 chip = self.family + self.device
 
+                tool_params = self.get_tool_params()
+
                 self.edam = {
                     'files': self.files,
                     'name': self.project_name,
@@ -65,7 +68,8 @@ class VPR(Toolchain):
                                     'package': self.package,
                                     'vendor': 'xilinx',
                                     'builddir': '.',
-                                    'pnr': 'vpr'
+                                    'pnr': 'vpr',
+                                    'options': tool_params,
                                 }
                         }
                 }
@@ -85,6 +89,18 @@ class VPR(Toolchain):
                 self.backend.build_main(self.top + '.fasm')
             with Timed(self, 'bitstream'):
                 self.backend.build_main(self.top + '.bit')
+
+    def get_tool_params(self):
+        if self.params_file:
+            opt_helper = ToolParametersHelper('vpr', '--', self.params_file)
+            params = opt_helper.get_all_params_combinations()
+
+            assert len(params) == 1
+            return " ".join(params[0])
+        elif self.params_string:
+            return self.params_string
+        else:
+            return None
 
     def get_critical_paths(self, clocks, timing):
 

--- a/symbiflow.py
+++ b/symbiflow.py
@@ -162,7 +162,7 @@ class VPR(Toolchain):
 
         with open(route_log, 'r') as fp:
             for l in fp:
-                if l.startswith("Final critical path:"):
+                if "Final critical path" in l and "Fmax" in l:
                     clk = 'clk'
                     fields = l.split(",")
                     cpd = float(fields[0].split(":")[1].split()[0].strip())
@@ -172,9 +172,9 @@ class VPR(Toolchain):
                     intra_domain_processing = True
                     continue
 
-                if intra_domain_processing is True:
+                if intra_domain_processing:
                     if len(l.strip('\n')) == 0:
-                        processing = False
+                        intra_domain_processing = False
                         continue
 
                     fields = l.split(':')

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import os
+from itertools import product
+
+from fpgaperf import get_projects, get_toolchains
+
+def get_device_info(constraint):
+    """Returns the device information:
+        - FPGA family
+        - FPGA part
+        - board
+    """
+    full_info, extension = os.path.splitext(constraint)
+    return full_info.split('_') + [extension.lstrip('.')]
+
+class Tasks:
+    """Class to generate and hold the task lists that needs to be run
+    exhaustively by FPGA tool perf."""
+
+    def __init__(self, src_dir):
+        self.src_dir = src_dir
+        self.MANDATORY_CONSTRAINTS = {
+            "vivado": "xdc",
+            "vpr": "pcf",
+            "vivado-yosys": "xdc",
+            "nextpnr": "xdc",
+        }
+
+        self.tasks = self.iter_options()
+
+    def iter_options(self):
+        """Returns all the possible combination of:
+            - projects,
+            - toolchains,
+            - families,
+            - devices,
+            - packages
+            - boards.
+
+        Example:
+        - path structure:    src/<project>/<toolchain>/<family>_<device>_<package>_<board>.<constraint>
+        - valid combination: src/oneblink/vpr/xc7_a35t_csg324-1_arty.pcf
+        """
+
+        projects = get_projects()
+        toolchains = get_toolchains()
+
+        combinations = set()
+        for project, toolchain in list(product(projects, toolchains)):
+            constraint_path = os.path.join(self.src_dir, project, 'constr', toolchain)
+
+            if toolchain not in self.MANDATORY_CONSTRAINTS.keys():
+                continue
+
+            if not os.path.exists(constraint_path):
+                continue
+
+            for constraint in os.listdir(constraint_path):
+                family, device, package, board, extension = get_device_info(constraint)
+
+                if extension not in self.MANDATORY_CONSTRAINTS[toolchain]:
+                    continue
+
+                combinations.add(
+                    (project, toolchain, family, device, package, board)
+                )
+
+        return combinations
+
+    def get_tasks(self, args):
+        """Returns all the tasks filtering out the ones that do not correspond
+        to the selected criteria"""
+
+        tasks = []
+
+        for task in self.tasks:
+            take_task = True
+            for arg in args.values():
+                if arg is None:
+                    continue
+
+                if not any(value in arg for value in task):
+                    take_task = False
+                    break
+
+            if take_task:
+                tasks.append(task)
+
+        return tasks

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 
 import os
 from itertools import product
@@ -19,6 +28,7 @@ def get_device_info(constraint):
 class Tasks:
     """Class to generate and hold the task lists that needs to be run
     exhaustively by FPGA tool perf."""
+
     def __init__(self, src_dir):
         self.src_dir = src_dir
         self.MANDATORY_CONSTRAINTS = {

--- a/tasks.py
+++ b/tasks.py
@@ -28,7 +28,6 @@ def get_device_info(constraint):
 class Tasks:
     """Class to generate and hold the task lists that needs to be run
     exhaustively by FPGA tool perf."""
-
     def __init__(self, src_dir):
         self.src_dir = src_dir
         self.MANDATORY_CONSTRAINTS = {

--- a/tasks.py
+++ b/tasks.py
@@ -5,6 +5,7 @@ from itertools import product
 
 from fpgaperf import get_projects, get_toolchains
 
+
 def get_device_info(constraint):
     """Returns the device information:
         - FPGA family
@@ -14,10 +15,10 @@ def get_device_info(constraint):
     full_info, extension = os.path.splitext(constraint)
     return full_info.split('_') + [extension.lstrip('.')]
 
+
 class Tasks:
     """Class to generate and hold the task lists that needs to be run
     exhaustively by FPGA tool perf."""
-
     def __init__(self, src_dir):
         self.src_dir = src_dir
         self.MANDATORY_CONSTRAINTS = {
@@ -48,7 +49,9 @@ class Tasks:
 
         combinations = set()
         for project, toolchain in list(product(projects, toolchains)):
-            constraint_path = os.path.join(self.src_dir, project, 'constr', toolchain)
+            constraint_path = os.path.join(
+                self.src_dir, project, 'constr', toolchain
+            )
 
             if toolchain not in self.MANDATORY_CONSTRAINTS.keys():
                 continue
@@ -57,7 +60,9 @@ class Tasks:
                 continue
 
             for constraint in os.listdir(constraint_path):
-                family, device, package, board, extension = get_device_info(constraint)
+                family, device, package, board, extension = get_device_info(
+                    constraint
+                )
 
                 if extension not in self.MANDATORY_CONSTRAINTS[toolchain]:
                     continue

--- a/tool_parameters.py
+++ b/tool_parameters.py
@@ -4,13 +4,17 @@ import os
 import json
 import itertools
 
-class ToolParametersHelper:
 
+class ToolParametersHelper:
     def __init__(self, toolchain, params_file='params.json'):
-        self.params_path = os.path.join(os.getcwd(), 'tool_parameters', toolchain, params_file)
+        self.params_path = os.path.join(
+            os.getcwd(), 'tool_parameters', toolchain, params_file
+        )
         self.params = None
 
-        assert os.path.exists(self.params_path), "Parameters file {} does not exist.".format(params_file)
+        assert os.path.exists(
+            self.params_path
+        ), "Parameters file {} does not exist.".format(params_file)
 
         with open(self.params_path, 'r') as params_file:
             self.params = json.load(params_file)
@@ -24,7 +28,9 @@ class ToolParametersHelper:
             param_combinations = []
 
             for value in values:
-                param_combinations.append("{}{} {}".format(param_prefix, param, value))
+                param_combinations.append(
+                    "{}{} {}".format(param_prefix, param, value)
+                )
 
             all_params.append(param_combinations)
 

--- a/tool_parameters.py
+++ b/tool_parameters.py
@@ -14,7 +14,7 @@ class ToolParametersHelper:
 
         assert os.path.exists(
             self.params_path
-        ), "Parameters file {} does not exist.".format(params_file)
+        ), "Parameters file {} does not exist.".format(self.params_path)
 
         with open(self.params_path, 'r') as params_file:
             self.params = json.load(params_file)

--- a/tool_parameters.py
+++ b/tool_parameters.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import itertools
+
+class ToolParametersHelper:
+
+    def __init__(self, toolchain, params_file='params.json'):
+        self.params_path = os.path.join(os.getcwd(), 'tool_parameters', toolchain, params_file)
+        self.params = None
+
+        assert os.path.exists(self.params_path), "Parameters file {} does not exist.".format(params_file)
+
+        with open(self.params_path, 'r') as params_file:
+            self.params = json.load(params_file)
+
+    def get_all_params_combinations(self):
+        all_params = []
+
+        param_prefix = self.params['param_prefix']
+
+        for param, values in self.params['params'].items():
+            param_combinations = []
+
+            for value in values:
+                param_combinations.append("{}{} {}".format(param_prefix, param, value))
+
+            all_params.append(param_combinations)
+
+        return list(itertools.product(*all_params))
+
+    def add_param(self, param, values=[], overwrite=True):
+        if param in self.params and overwrite:
+            self.params[param] = values
+        else:
+            print("param {} cannot be overwritten.".format(param))
+
+    def add_param_values(self, param, values=[]):
+        old_values = self.params[param]
+        new_values = list(set(old_values | values))
+        self.add_params(param, new_values)
+
+    def remove_param(self, param):
+        self.params.pop(param, None)

--- a/tool_parameters/vpr/parameters.json
+++ b/tool_parameters/vpr/parameters.json
@@ -1,0 +1,24 @@
+{
+    "param_prefix": "--",
+    "params": {
+        "max_router_iterations": [500],
+        "routing_failure_predictor": ["off"],
+        "router_high_fanout_threshold": [-1],
+        "constant_net_method": ["route"],
+        "route_chan_width": [500, 400],
+        "router_heap": ["bucket"],
+        "router_lookahead": ["connection_box_map"],
+        "quick_check_route": ["on"],
+        "clock_modeling": ["route"],
+        "place_delta_delay_matrix_calculation_method": ["dijkstra"],
+        "strict_checks": ["off"],
+        "allow_dangling_combinational_nodes": ["on"],
+        "disable_errors": ["check_unbuffered_edges:check_route"],
+        "congested_routing_iteration_threshold": [0.8],
+        "incremental_reroute_delay_ripup": ["off"],
+        "base_cost_type": ["delay_normalized_length_bounded"],
+        "bb_factor": [10, 20],
+        "initial_pres_fac": [3.0, 4.0],
+        "check_rr_graph": ["off"]
+    }
+}

--- a/tool_parameters/vpr/parameters.json
+++ b/tool_parameters/vpr/parameters.json
@@ -5,7 +5,7 @@
         "routing_failure_predictor": ["off"],
         "router_high_fanout_threshold": [-1],
         "constant_net_method": ["route"],
-        "route_chan_width": [500, 400],
+        "route_chan_width": [500],
         "router_heap": ["bucket"],
         "router_lookahead": ["connection_box_map"],
         "quick_check_route": ["on"],
@@ -18,7 +18,7 @@
         "incremental_reroute_delay_ripup": ["off"],
         "base_cost_type": ["delay_normalized_length_bounded"],
         "bb_factor": [10, 20],
-        "initial_pres_fac": [3.0, 4.0],
+        "initial_pres_fac": [4.0],
         "check_rr_graph": ["off"]
     }
 }

--- a/toolchain.py
+++ b/toolchain.py
@@ -33,6 +33,7 @@ class Toolchain:
         self._carry = None
         self.seed = None
         self.build = None
+        self.build_type = None
         self.date = datetime.datetime.utcnow()
 
         self.family = None
@@ -86,6 +87,9 @@ class Toolchain:
             self.project_name, self.toolchain, self.family, self.part,
             self.board
         )
+
+        if self.build_type:
+            ret += '_' + self.build_type
 
         if self.build:
             ret += '_' + self.build
@@ -293,6 +297,7 @@ class Toolchain:
             'carry': self.carry,
             'seed': self.seed,
             'build': self.build,
+            'build_type': self.build_type,
             'date': date_str,
             'toolchain': self.toolchain,
             'strategy': self.strategy,

--- a/toolchain.py
+++ b/toolchain.py
@@ -27,6 +27,8 @@ class Toolchain:
         self.pcf = None
         self.sdc = None
         self.xdc = None
+        self.params_file = None
+        self.params_string = None
         self._strategy = None
         self._carry = None
         self.seed = None
@@ -84,9 +86,14 @@ class Toolchain:
             self.project_name, self.toolchain, self.family, self.part,
             self.board
         )
+
+        if self.build:
+            ret += '_' + self.build
+
         op = self.optstr()
         if op:
             ret += '_' + op
+
         return ret
 
     @property
@@ -146,6 +153,8 @@ class Toolchain:
         device,
         package,
         board,
+        params_file,
+        params_string,
         out_dir=None,
         out_prefix=None,
     ):
@@ -154,6 +163,9 @@ class Toolchain:
         self.package = package
         self.part = "".join((device, package))
         self.board = board
+
+        self.params_file = params_file
+        self.params_string = params_string
 
         self.project_name = project['name']
         self.srcs = self.canonicalize(project['srcs'])
@@ -284,6 +296,7 @@ class Toolchain:
             'date': date_str,
             'toolchain': self.toolchain,
             'strategy': self.strategy,
+            'parameters': self.params_file or self.params_string,
 
             # canonicalize
             'sources': [x.replace(os.getcwd(), '.') for x in self.srcs],


### PR DESCRIPTION
This PR has a double purpose:

- allowing to inject custom parameters for the tool (currently it is enabled for VPR only, but could be expanded in the future to be more flexible).
- make it possible to easily running multiple times the tests to gather more samples.

Note: Given that the exhaust script is used mainly to perform a batch of tests, I have limited the freedom degree to be able to choose only `toolchains` and `projects` (from a user perspective).
The user can still run single tests using `fpgaperf.py`.

TODO:
- [x] test multiple runs with all of them gathering information on CI
- [x] test multiple runs with different options for VPR