### PR TITLE
Add yosys_synth_options and use the options from nextpnr-xilinx

### DIFF
--- a/symbiflow.py
+++ b/symbiflow.py
@@ -508,11 +508,21 @@ class NextpnrXilinx(Toolchain):
                         {
                             'symbiflow':
                                 {
-                                    'part': chip,
-                                    'package': self.package,
-                                    'vendor': 'xilinx',
-                                    'builddir': '.',
-                                    'pnr': 'nextpnr'
+                                    'part':
+                                        chip,
+                                    'package':
+                                        self.package,
+                                    'vendor':
+                                        'xilinx',
+                                    'builddir':
+                                        '.',
+                                    'pnr':
+                                        'nextpnr',
+                                    'yosys_synth_options':
+                                        [
+                                            "-flatten", "-nowidelut", "-abc9",
+                                            "-arch xc7"
+                                        ]
                                 }
                         }
                 }


### PR DESCRIPTION
The corresponding PR for edalize: https://github.com/SymbiFlow/edalize/pull/47