### PR TITLE
nextpnr: enable fasm2bels

### DIFF
--- a/fasm2bels.py
+++ b/fasm2bels.py
@@ -1,0 +1,78 @@
+import os
+
+import edalize
+
+from toolchain import Toolchain
+from symbiflow import VPR, NextpnrXilinx
+from utils import Timed, get_vivado_max_freq
+
+
+class VPRFasm2Bels(VPR):
+    """This class is used to generate the VPR -> Fasm2bels flow.
+
+    fasm2bels is a tool that, given a bitstream, can reproduce the original netlist
+    and run it through Vivado to get a mean of comparison with the VPR outputs.
+
+    fasm2bels generates two different files:
+        - verilog netlist corresponding to the bitstream
+        - tcl script to force the placement and routing
+
+    It then runs the two generated outputs through Vivado and gets the timing reports.
+
+    NOTE: This flow is purely for verification purposes and is intended for developers only.
+          In addition, this flow makes use of Vivado.
+    """
+    def __init__(self, rootdir):
+        Toolchain.__init__(self, rootdir)
+        self.toolchain = 'vpr-fasm2bels'
+        self.files = []
+        self.fasm2bels = True
+
+        self.dbroot = os.getenv('XRAY_DATABASE_DIR', None)
+
+        assert self.dbroot
+
+    def max_freq(self):
+        report_file = os.path.join(self.out_dir, 'timing_summary.rpt')
+        return get_vivado_max_freq(report_file)
+
+    def run_steps(self):
+        with Timed(self, 'synthesis'):
+            self.backend.build_main(self.top + '.eblif')
+        with Timed(self, 'pack'):
+            self.backend.build_main(self.top + '.net')
+        with Timed(self, 'place'):
+            self.backend.build_main(self.top + '.place')
+        with Timed(self, 'route'):
+            self.backend.build_main(self.top + '.route')
+        with Timed(self, 'fasm'):
+            self.backend.build_main(self.top + '.fasm')
+        with Timed(self, 'bitstream'):
+            self.backend.build_main(self.top + '.bit')
+        with Timed(self, 'fasm2bels'):
+            self.backend.build_main('timing_summary.rpt')
+
+
+class NextpnrXilinxFasm2Bels(NextpnrXilinx):
+    '''nextpnr using Yosys for synthesis'''
+    carries = (False, )
+
+    def __init__(self, rootdir):
+        Toolchain.__init__(self, rootdir)
+        self.toolchain = 'nextpnr-xilinx-fasm2bels'
+        self.files = []
+        self.fasm2bels = True
+
+        self.dbroot = os.getenv('XRAY_DATABASE_DIR', None)
+
+        assert self.dbroot
+
+    def max_freq(self):
+        report_file = os.path.join(self.out_dir, 'timing_summary.rpt')
+        return get_vivado_max_freq(report_file)
+
+    def run_steps(self):
+        with Timed(self, 'bitstream'):
+            self.backend.build_main(self.project_name + '.bit')
+        with Timed(self, 'fasm2bels'):
+            self.backend.build_main('timing_summary.rpt')

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -20,9 +20,8 @@ from icestorm import NextpnrIcestorm
 from icestorm import Arachne
 from vivado import Vivado
 from vivado import VivadoYosys
-from symbiflow import VPR
-from symbiflow import VPRFasm2Bels
-from symbiflow import NextpnrXilinx
+from symbiflow import VPR, NextpnrXilinx
+from fasm2bels import VPRFasm2Bels, NextpnrXilinxFasm2Bels
 from radiant import RadiantSynpro
 from radiant import RadiantLSE
 from icecube import Icecube2Synpro
@@ -121,6 +120,7 @@ toolchains = {
     'vpr-fasm2bels': VPRFasm2Bels,
     'nextpnr-ice40': NextpnrIcestorm,
     'nextpnr-xilinx': NextpnrXilinx,
+    'nextpnr-xilinx-fasm2bels': NextpnrXilinxFasm2Bels,
     'icecube2-synpro': Icecube2Synpro,
     'icecube2-lse': Icecube2LSE,
     'icecube2-yosys': Icecube2Yosys,

--- a/project/blinky.json
+++ b/project/blinky.json
@@ -17,6 +17,9 @@
         "nextpnr-xilinx": {
             "arty": ["arty.xdc"]
         },
+        "nextpnr-xilinx-fasm2bels": {
+            "arty": ["arty.xdc", "arty.pcf"]
+        },
         "vivado": {
             "arty": ["arty.xdc"]
         },

--- a/src/blinky/blinky.v
+++ b/src/blinky/blinky.v
@@ -1,4 +1,4 @@
-module top (input clk_i, input [3:0] sw, output [11:0] led);
+module top (input clk_i, output [11:0] led);
 
     //assign led = {&sw, |sw, ^sw, ~^sw};
 

--- a/src/blinky/constr/arty.pcf
+++ b/src/blinky/constr/arty.pcf
@@ -10,8 +10,4 @@ set_io led[8] E1
 set_io led[9] G4 
 set_io led[10] H4
 set_io led[11] K2
-set_io sw[0] A8
-set_io sw[1] C11
-set_io sw[2] C10
-set_io sw[3] A10
 set_io clk_i E3

--- a/src/blinky/constr/arty.xdc
+++ b/src/blinky/constr/arty.xdc
@@ -14,12 +14,6 @@ set_property LOC G4 [get_ports led[9]]
 set_property LOC H4 [get_ports led[10]]
 set_property LOC K2 [get_ports led[11]]
 
-# second row
-# set_property LOC H5 [get_ports led[12]]
-# set_property LOC J5 [get_ports led[13]]
-# set_property LOC T9 [get_ports led[14]]
-# set_property LOC T10 [get_ports led[15]]
-
 set_property IOSTANDARD LVCMOS33 [get_ports led[0]]
 set_property IOSTANDARD LVCMOS33 [get_ports led[1]]
 set_property IOSTANDARD LVCMOS33 [get_ports led[2]]
@@ -36,16 +30,6 @@ set_property IOSTANDARD LVCMOS33 [get_ports led[12]]
 set_property IOSTANDARD LVCMOS33 [get_ports led[13]]
 set_property IOSTANDARD LVCMOS33 [get_ports led[14]]
 set_property IOSTANDARD LVCMOS33 [get_ports led[15]]
-
-set_property LOC A8 [get_ports sw[0]]
-set_property LOC C11 [get_ports sw[1]]
-set_property LOC C10 [get_ports sw[2]]
-set_property LOC A10 [get_ports sw[3]]
-
-set_property IOSTANDARD LVCMOS33 [get_ports sw[0]]
-set_property IOSTANDARD LVCMOS33 [get_ports sw[1]]
-set_property IOSTANDARD LVCMOS33 [get_ports sw[2]]
-set_property IOSTANDARD LVCMOS33 [get_ports sw[3]]
 
 set_property LOC E3 [get_ports clk_i]
 set_property IOSTANDARD LVCMOS33 [get_ports clk_i]

--- a/tasks.py
+++ b/tasks.py
@@ -27,6 +27,7 @@ class Tasks:
             "vpr-fasm2bels": "pcf",
             "vivado-yosys": "xdc",
             "nextpnr-xilinx": "xdc",
+            "nextpnr-xilinx-fasm2bels": "xdc",
             "nextpnr-ice40": "pcf",
         }
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This enables to run fasm2bels on the nextpnr-generated bitstreams.

As a side effect, this PR moves fasm2bels related flows in a separate file to keep things cleaner.

This fixes https://github.com/SymbiFlow/fpga-tool-perf/issues/159