### PR TITLE
use latest yosys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MULTIPLE_RUN_ITERATIONS ?= 2
 
 SYMBIFLOW_ARCHIVE = symbiflow.tar.xz
 # FIXME: make this dynamic: https://github.com/SymbiFlow/fpga-tool-perf/issues/75
-SYMBIFLOW_URL = "https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/41/20200716-110409/symbiflow-arch-defs-install-f1b25ddc.tar.xz"
+SYMBIFLOW_URL = "https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/44/20200721-072851/symbiflow-arch-defs-install-206bd565.tar.xz"
 
 all: format
 

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -3,8 +3,8 @@ channels:
   - defaults
   - symbiflow
 dependencies:
-  - symbiflow-yosys=0.8_3925_g6bccd35a
-  - symbiflow-yosys-plugins=1.0.0.7_0032_g104f4fc
+  - symbiflow-yosys=0.8_6021_gd8b2d1a2
+  - symbiflow-yosys-plugins=1.0.0.7_0048_gaa1b583
   - symbiflow-vtr=8.0.0.rc2_4003_g8980e4621
   - nextpnr-xilinx
   - nextpnr-ice40

--- a/project/baselitex.json
+++ b/project/baselitex.json
@@ -20,6 +20,9 @@
         "vivado-yosys": {
             "arty": ["arty-vivado.xdc"]
         },
+        "nextpnr-xilinx": {
+            "arty": ["arty-nextpnr.xdc"]
+        },
         "vpr": {
             "arty": ["arty.pcf", "arty.sdc", "arty-vpr.xdc"]
         },

--- a/project/blinky.json
+++ b/project/blinky.json
@@ -17,6 +17,9 @@
         "nextpnr-xilinx": {
             "arty": ["arty.xdc"]
         },
+        "nextpnr-xilinx-fasm2bels": {
+            "arty": ["arty.xdc", "arty.pcf"]
+        },
         "vivado": {
             "arty": ["arty.xdc"]
         },

--- a/project/murax.json
+++ b/project/murax.json
@@ -15,6 +15,12 @@
         "vpr": {
             "basys3": ["basys3.pcf", "basys3.sdc"]
         },
+        "vpr-fasm2bels": {
+            "basys3": ["basys3.pcf", "basys3.sdc"]
+        },
+        "nextpnr-xilinx": {
+            "basys3": ["basys3-nextpnr.xdc"]
+        },
         "vivado-yosys": {
             "basys3": ["basys3.xdc"]
         },

--- a/project/picosoc.json
+++ b/project/picosoc.json
@@ -13,6 +13,9 @@
         "vpr": {
             "basys3": ["basys3.pcf", "basys3.sdc"]
         },
+        "nextpnr-xilinx": {
+            "basys3": ["basys3-nextpnr.xdc"]
+        },
         "vivado": {
             "basys3": ["basys3.xdc"]
         },

--- a/src/ibex/constr/arty.sdc
+++ b/src/ibex/constr/arty.sdc
@@ -2,3 +2,4 @@ create_clock -period 10.0 clkgen.IO_CLK -waveform {0.000 5.000}
 create_clock -period 10.0 clkgen.io_clk_bufg -waveform {0.000 5.000}
 create_clock -period 10.0 clkgen.clk_pll_fb -waveform {0.000 5.000}
 create_clock -period 40.0 clkgen.clk_50_unbuf -waveform {0.000 20.000}
+create_clock -period 40.0 clkgen.clk_sys -waveform {0.000 20.000}

--- a/vivado.py
+++ b/vivado.py
@@ -234,7 +234,7 @@ class VivadoYosys(Vivado):
     def __init__(self, rootdir):
         Vivado.__init__(self, rootdir)
         self.synthtool = 'yosys'
-        self.synthoptions = ['-iopad', '-arch xc7', '-abc9', '-flatten']
+        self.synthoptions = ['-iopad', '-arch xc7', '-flatten']
         self.toolchain = 'yosys-vivado'
 
     @staticmethod


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR modifies the yosys version to the latest master+wip, so we can enable nextpnr-xilinx as well for all the supported tests.

In addition this PR modifies the following:
- fix to ibex SDC to have clock correctly constrained;
- do not use abc9 in yosys+vivado flow: this needs to be fixed. Apparently the ibex test results in abc9 issues, which end up in segfaults. 