### PR TITLE
icestorm: have max_freq expressed in Hz instead of MHz

### DIFF
--- a/icestorm.py
+++ b/icestorm.py
@@ -68,7 +68,7 @@ class Icestorm(Toolchain):
             m = re.match(r'Total path delay: .*s \((.*) (.*)\)', l)
             if m:
                 assert m.group(2) == 'MHz'
-                ret['max_freq'] = float(m.group(1))
+                ret['max_freq'] = float(m.group(1)) * 1e6
         return ret
 
     def max_freq(self):


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to have frequency results in the meta.json file for ice40 consistent with all the other results from other toolchains. Fixes https://github.com/SymbiFlow/fpga-tool-perf/issues/190
