### PR TITLE
Timing Consistency Between Toolchains

### DIFF
--- a/fasm2bels.py
+++ b/fasm2bels.py
@@ -64,6 +64,7 @@ class VPRFasm2Bels(VPR):
         self.backend.build_main(self.top + '.fasm')
         with Timed(self, 'bitstream'):
             self.backend.build_main(self.top + '.bit')
+
         with Timed(self, 'fasm2bels'):
             self.backend.build_main('timing_summary.rpt')
 
@@ -97,5 +98,6 @@ class NextpnrXilinxFasm2Bels(NextpnrXilinx):
     def run_steps(self):
         with Timed(self, 'bitstream'):
             self.backend.build_main(self.project_name + '.bit')
+
         with Timed(self, 'fasm2bels'):
             self.backend.build_main('timing_summary.rpt')

--- a/icecube.py
+++ b/icecube.py
@@ -39,7 +39,6 @@ class Icecube2(Toolchain):
             if self.strategy:
                 args += " --strategy %s" % (self.strategy, )
             self.cmd(root_dir + "/icecubed.sh", args, env=env)
-
             self.cmd("iceunpack", "my.bin my.asc")
 
         self.cmd("icetime", "-tmd %s my.asc" % (self.device, ))

--- a/radiant.py
+++ b/radiant.py
@@ -48,7 +48,6 @@ class Radiant(Toolchain):
             if self.strategy:
                 args += " --strategy %s" % self.strategy
             self.cmd(root_dir + "/radiant.sh", args, env=env)
-
             self.cmd("iceunpack", "my.bin my.asc")
 
         self.cmd("icetime", "-tmd up5k my.asc")

--- a/symbiflow.py
+++ b/symbiflow.py
@@ -35,10 +35,13 @@ class VPR(Toolchain):
         self.backend.build_main(self.top + '.eblif')
         with Timed(self, 'pack_all', unprinted_runtime=True):
             self.backend.build_main(self.top + '.net')
+
         with Timed(self, 'place_all', unprinted_runtime=True):
             self.backend.build_main(self.top + '.place')
+
         with Timed(self, 'route_all', unprinted_runtime=True):
             self.backend.build_main(self.top + '.route')
+
         self.backend.build_main(self.top + '.fasm')
         with Timed(self, 'bitstream'):
             self.backend.build_main(self.top + '.bit')
@@ -159,7 +162,9 @@ class VPR(Toolchain):
                     edam=self.edam, work_root=self.out_dir
                 )
                 self.backend.configure("")
+
             self.run_steps()
+
         self.add_runtimes()
         self.add_wirelength()
         self.add_maximum_memory_use()
@@ -728,6 +733,7 @@ class NextpnrXilinx(Toolchain):
                     edam=self.edam, work_root=self.out_dir
                 )
                 self.backend.configure("")
+
             self.backend.build_main(self.project_name + '.fasm')
             self.run_steps()
 

--- a/symbiflow.py
+++ b/symbiflow.py
@@ -159,11 +159,10 @@ class VPR(Toolchain):
                     edam=self.edam, work_root=self.out_dir
                 )
                 self.backend.configure("")
-
             self.run_steps()
-            self.add_runtimes()
-            self.add_wirelength()
-            self.add_maximum_memory_use()
+        self.add_runtimes()
+        self.add_wirelength()
+        self.add_maximum_memory_use()
 
     def get_tool_params(self):
         if self.params_file:
@@ -729,13 +728,11 @@ class NextpnrXilinx(Toolchain):
                     edam=self.edam, work_root=self.out_dir
                 )
                 self.backend.configure("")
-
             self.backend.build_main(self.project_name + '.fasm')
-
             self.run_steps()
 
-            self.add_runtimes()
-            self.add_wirelength()
+        self.add_runtimes()
+        self.add_wirelength()
 
     def add_wirelength(self):
         def get_wirelength(log_file):

--- a/toolchain.py
+++ b/toolchain.py
@@ -64,9 +64,6 @@ class Toolchain:
         self.wirelength = None
         self.maximum_memory_use = None
 
-        with Timed(self, 'nop'):
-            subprocess.check_call("true", shell=True, cwd=self.out_dir)
-
     def canonicalize(self, fns):
         return [os.path.realpath(self.rootdir + '/' + fn) for fn in fns]
 
@@ -271,7 +268,6 @@ class Toolchain:
             'bitstream': ['write_bitstream', 'bitstream'],
             'reports': ['report_power', 'report_methodology', 'report_drc'],
             'total': ['total'],
-            'nop': ['nop'],
             'fasm2bels': ['fasm2bels'],
             'link design': ['link_design'],
             'phys opt design': ['phys_opt_design']

--- a/vivado.py
+++ b/vivado.py
@@ -78,68 +78,65 @@ class Vivado(Toolchain):
             self.add_runtime(t, impl_times[t])
 
     def run(self):
-        with Timed(self, 'prepare'):
-            os.makedirs(self.out_dir, exist_ok=True)
-            for f in self.srcs:
-                if f.endswith(".vhd") or f.endswith(".vhdl"):
-                    self.files.append(
-                        {
-                            'name': os.path.realpath(f),
-                            'file_type': 'vhdlSource'
-                        }
-                    )
-                elif f.endswith(".v"):
-                    self.files.append(
-                        {
-                            'name': os.path.realpath(f),
-                            'file_type': 'verilogSource'
-                        }
-                    )
-
-            self.files.append(
-                {
-                    'name': os.path.realpath(self.xdc),
-                    'file_type': 'xdc'
-                }
-            )
-
-            chip = self.family + self.device + self.package
-
-            vivado_settings = os.getenv('VIVADO_SETTINGS')
-
-            self.edam = {
-                'files': self.files,
-                'name': self.project_name,
-                'toplevel': self.top,
-                'parameters':
-                    {
-                        'VIVADO':
-                            {
-                                'paramtype': 'vlogdefine',
-                                'datatype': 'int',
-                                'default': 1,
-                            },
-                    },
-                'tool_options':
-                    {
-                        'vivado':
-                            {
-                                'part': chip,
-                                'synth': self.synthtool,
-                                'vivado-settings': vivado_settings,
-                                'yosys_synth_options': self.synthoptions,
-                            }
-                    }
-            }
-
-            self.backend = edalize.get_edatool('vivado')(
-                edam=self.edam, work_root=self.out_dir
-            )
-            self.backend.configure("")
-
         with Timed(self, 'total'):
-            self.backend.build()
+            with Timed(self, 'prepare'):
+                os.makedirs(self.out_dir, exist_ok=True)
+                for f in self.srcs:
+                    if f.endswith(".vhd") or f.endswith(".vhdl"):
+                        self.files.append(
+                            {
+                                'name': os.path.realpath(f),
+                                'file_type': 'vhdlSource'
+                            }
+                        )
+                    elif f.endswith(".v"):
+                        self.files.append(
+                            {
+                                'name': os.path.realpath(f),
+                                'file_type': 'verilogSource'
+                            }
+                        )
 
+                self.files.append(
+                    {
+                        'name': os.path.realpath(self.xdc),
+                        'file_type': 'xdc'
+                    }
+                )
+
+                chip = self.family + self.device + self.package
+
+                vivado_settings = os.getenv('VIVADO_SETTINGS')
+
+                self.edam = {
+                    'files': self.files,
+                    'name': self.project_name,
+                    'toplevel': self.top,
+                    'parameters':
+                        {
+                            'VIVADO':
+                                {
+                                    'paramtype': 'vlogdefine',
+                                    'datatype': 'int',
+                                    'default': 1,
+                                },
+                        },
+                    'tool_options':
+                        {
+                            'vivado':
+                                {
+                                    'part': chip,
+                                    'synth': self.synthtool,
+                                    'vivado-settings': vivado_settings,
+                                    'yosys_synth_options': self.synthoptions,
+                                }
+                        }
+                }
+                self.backend = edalize.get_edatool('vivado')(
+                    edam=self.edam, work_root=self.out_dir
+                )
+                self.backend.configure("")
+            self.backend.build()
         self.add_runtimes()
         self.add_maximum_memory_use()
 

--- a/vivado.py
+++ b/vivado.py
@@ -136,7 +136,9 @@ class Vivado(Toolchain):
                     edam=self.edam, work_root=self.out_dir
                 )
                 self.backend.configure("")
+
             self.backend.build()
+
         self.add_runtimes()
         self.add_maximum_memory_use()
 


### PR DESCRIPTION
I found two issues with timing consistency that I have addressed with this pull request.

Each toolchain's runtime includes a `prepare` time, as well as a `self.add_runtimes()`. The problem is that while `prepare` time is included in symbiflow's `total` time, it is not included in vivado's total time. The other inconsistency is that the `self.add_runtimes()` function is included in symbiflow's `total` but not in vivado's.

These are my solutions:
1. In `symbiflow.py`, I removed the `self.add_runtimes()` from the `total` runtime, since it isn't actually a part of the running toolchain, simply a gathering of runtimes. This simply meant deleting a tab from it, so it takes place after (and not during) the `with Timed(self, 'total'):` code block.
2. In `vivado.py`, I moved the `with Timed(self, 'total'):` block to the front of the function, to include prepare. It looks confusing through Github, but I really just moved that one line and tabbed the `with Timed(self, 'prepare'):` block to be a part of it.

This clears up all the consistency issues that I know of.

fixes #221