### PR TITLE
Minor Enhancements for Usability

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -83,8 +83,7 @@ class Runner:
                 eprint("---------------------\n")
 
     def run(self):
-        if not os.path.exists(self.out_prefix):
-            os.makedirs(self.out_prefix)
+        os.makedirs(self.out_prefix, exist_ok=True)
         print('Writing to %s' % self.out_prefix)
 
         with Pool(cpu_count()) as pool:

--- a/runner.py
+++ b/runner.py
@@ -85,6 +85,7 @@ class Runner:
     def run(self):
         if not os.path.exists(self.out_prefix):
             os.makedirs(self.out_prefix)
+        print('Writing to %s' % self.out_prefix)
 
         with Pool(cpu_count()) as pool:
             for _ in tqdm.tqdm(pool.imap_unordered(self.worker,

--- a/runner.py
+++ b/runner.py
@@ -83,7 +83,7 @@ class Runner:
                 eprint("---------------------\n")
 
     def run(self):
-        os.makedirs(self.out_prefix, exist_ok=True)
+        os.makedirs(os.path.expanduser(self.out_prefix), exist_ok=True)
         print('Writing to %s' % self.out_prefix)
 
         with Pool(cpu_count()) as pool:

--- a/toolchain.py
+++ b/toolchain.py
@@ -195,7 +195,7 @@ class Toolchain:
 
         out_prefix = out_prefix or 'build'
         if not os.path.exists(out_prefix):
-            os.mkdir(out_prefix)
+            os.makedirs(out_prefix)
 
         if out_dir is None:
             out_dir = out_prefix + "/" + self.design()
@@ -203,7 +203,7 @@ class Toolchain:
         if overwrite and os.path.exists(out_dir):
             shutil.rmtree(out_dir)
         if not os.path.exists(out_dir):
-            os.mkdir(out_dir)
+            os.makedirs(out_dir)
         print('Writing to %s' % out_dir)
         data = project.get('data', None)
         if data:

--- a/toolchain.py
+++ b/toolchain.py
@@ -194,8 +194,7 @@ class Toolchain:
             self.clocks = project['clocks']
 
         out_prefix = out_prefix or 'build'
-        if not os.path.exists(out_prefix):
-            os.makedirs(out_prefix)
+        os.makedirs(out_prefix, exist_ok=True)
 
         if out_dir is None:
             out_dir = out_prefix + "/" + self.design()

--- a/toolchain.py
+++ b/toolchain.py
@@ -194,15 +194,14 @@ class Toolchain:
             self.clocks = project['clocks']
 
         out_prefix = out_prefix or 'build'
-        os.makedirs(out_prefix, exist_ok=True)
+        os.makedirs(os.path.expanduser(out_prefix), exist_ok=True)
 
         if out_dir is None:
             out_dir = out_prefix + "/" + self.design()
         self.out_dir = out_dir
         if overwrite and os.path.exists(out_dir):
             shutil.rmtree(out_dir)
-        if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
+        os.makedirs(os.path.expanduser(out_dir), exist_ok=True)
         print('Writing to %s' % out_dir)
         data = project.get('data', None)
         if data:


### PR DESCRIPTION
1. Adds the `Writing to <out_prefix>` statement to the exhaust run. Serves the same purpose as it does in `fpgaperf.py`.

2. Changes `os.mkdir()` to `os.makedirs()`. We recently made this change to the `exhaust.py` run. It will simply allow for more specific directory paths if the user is so inclined, without failing if there are multiple folders in the path yet to be created. This also makes it easier to use the `--out-prefix` and `--out-dir` arguments separately.