### PR TITLE
Implemented --overwrite Functionality

### DIFF
--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -143,6 +143,7 @@ def run(
     params_string=None,
     out_dir=None,
     out_prefix=None,
+    overwrite=False,
     verbose=False,
     strategy=None,
     seed=None,
@@ -207,6 +208,7 @@ def run(
         params_string,
         out_dir=out_dir,
         out_prefix=out_prefix,
+        overwrite=overwrite,
     )
     t.run()
     logger.debug("Printing Stats")
@@ -389,8 +391,14 @@ def main():
         'Analyze FPGA tool performance (MHz, resources, runtime, etc)'
     )
 
-    parser.add_argument('--verbose', action='store_true', help='')
-    parser.add_argument('--overwrite', action='store_true', help='')
+    parser.add_argument(
+        '--verbose', action='store_true', help='Print DEBUG Statements'
+    )
+    parser.add_argument(
+        '--overwrite',
+        action='store_true',
+        help='Overwrite the folder with this run'
+    )
     parser.add_argument('--board', default=None, help='Target board')
     parser.add_argument(
         '--params_file', default=None, help='Use custom tool parameters'
@@ -493,6 +501,7 @@ def main():
             params_string=args.params_string,
             out_dir=args.out_dir,
             out_prefix=args.out_prefix,
+            overwrite=args.overwrite,
             verbose=args.verbose,
             strategy=args.strategy,
             carry=args.carry,

--- a/runner.py
+++ b/runner.py
@@ -60,10 +60,11 @@ class Runner:
                     board,
                     toolchain,
                     project,
-                    None,  #options_file
-                    option,
+                    None,  #params_file
+                    option,  #params_string
                     None,  #out_dir
                     self.out_prefix,
+                    False,  #overwrite
                     self.verbose,
                     None,  #strategy
                     seed,

--- a/toolchain.py
+++ b/toolchain.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import glob
 import datetime
+import shutil
 from utils import Timed
 
 
@@ -168,6 +169,7 @@ class Toolchain:
         params_string,
         out_dir=None,
         out_prefix=None,
+        overwrite=False,
     ):
         self.family = family
         self.device = device
@@ -195,6 +197,8 @@ class Toolchain:
         if out_dir is None:
             out_dir = out_prefix + "/" + self.design()
         self.out_dir = out_dir
+        if overwrite and os.path.exists(out_dir):
+            shutil.rmtree(out_dir)
         if not os.path.exists(out_dir):
             os.mkdir(out_dir)
         print('Writing to %s' % out_dir)


### PR DESCRIPTION
This pull request implements `fpgaperf.py`'s `--overwrite` functionality by deleting the previous build of the same location. For example:
```
python3 fpgaperf.py --toolchain vivado --board basys3 --project oneblink
```
Running the above command will result in the folder: `fpga-tool-perf/build/oneblink_vivado_xc7_a35tcpg236-1_basys3_xdc_carry-n`. Repeating the same command has varying results, often either failing or resulting in inaccurate runtimes.
```
python3 fpgaperf.py --toolchain vivado --board basys3 --project oneblink --overwrite
```
Running the same command with `--overwrite` deletes the previous `fpga-tool-perf/build/oneblink_vivado_xc7_a35tcpg236-1_basys3_xdc_carry-n` folder and its contents and creates the folder again, where it then runs the build with no interference from previous files.