### PR TITLE
Exhaust Printing Fix

### DIFF
--- a/exhaust.py
+++ b/exhaust.py
@@ -31,7 +31,9 @@ def get_builds(out_prefix):
     return builds
 
 
-def print_summary_table(out_prefix, build_type, build_nr=None):
+def print_summary_table(
+    out_prefix, project, toolchain, build_type, build_nr=None
+):
     """Prints a summary table of the outcome of each test."""
     builds = get_builds(out_prefix)
     table_data = [
@@ -53,6 +55,10 @@ def print_summary_table(out_prefix, build_type, build_nr=None):
         row = list(re.match(pattern, build).groups())
 
         if build_type != row[5] or (build_nr and int(build_nr) != int(row[6])):
+            continue
+        if project and row[0] not in project:
+            continue
+        if toolchain and row[1] not in toolchain:
             continue
 
         # Check if metadata was generated
@@ -195,7 +201,10 @@ def main():
     runner.collect_results()
 
     logger.debug("Printing Summary Table")
-    result = print_summary_table(args.out_prefix, args.build_type, args.build)
+    result = print_summary_table(
+        args.out_prefix, args.project, args.toolchain, args.build_type,
+        args.build
+    )
 
     if not result and args.fail:
         print("ERROR: some tests have failed.")

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -118,19 +118,19 @@ def print_stats(t):
 
 toolchains = {
     'vivado': Vivado,
-    'vivado-yosys': VivadoYosys,
+    'yosys-vivado': VivadoYosys,
     'vpr': VPR,
     'vpr-fasm2bels': VPRFasm2Bels,
     'nextpnr-ice40': NextpnrIcestorm,
     'nextpnr-xilinx': NextpnrXilinx,
     'nextpnr-xilinx-fasm2bels': NextpnrXilinxFasm2Bels,
     # TODO: These are not currently be extensively tested
-    #'icecube2-synpro': Icecube2Synpro,
-    #'icecube2-lse': Icecube2LSE,
-    #'icecube2-yosys': Icecube2Yosys,
-    #'radiant-synpro': RadiantSynpro,
-    #'radiant-lse': RadiantLSE,
-    #'radiant-yosys': RadiantYosys,
+    #'synpro-icecube2': Icecube2Synpro,
+    #'lse-icecube2': Icecube2LSE,
+    #'yosys-icecube2': Icecube2Yosys,
+    #'synpro-radiant': RadiantSynpro,
+    #'lse-radiant': RadiantLSE,
+    #'yosys-radiant': RadiantYosys,
     #'radiant': VPR,
 }
 

--- a/icecube.py
+++ b/icecube.py
@@ -75,7 +75,7 @@ class Icecube2Synpro(Icecube2):
 
     def __init__(self):
         Icecube2.__init__(self)
-        self.toolchain = 'icecube2-synpro'
+        self.toolchain = 'synpro-icecube2'
 
     def syn(self):
         return "synpro"
@@ -94,7 +94,7 @@ class Icecube2LSE(Icecube2):
 
     def __init__(self):
         Icecube2.__init__(self)
-        self.toolchain = 'icecube2-lse'
+        self.toolchain = 'lse-icecube2'
 
     def syn(self):
         return "lse"
@@ -113,7 +113,7 @@ class Icecube2Yosys(Icecube2):
 
     def __init__(self):
         Icecube2.__init__(self)
-        self.toolchain = 'icecube2-yosys'
+        self.toolchain = 'yosys-icecube2'
 
     def syn(self):
         return "yosys-synpro"

--- a/project/baselitex.json
+++ b/project/baselitex.json
@@ -4,7 +4,7 @@
         "src/baselitex/baselitex_arty.v"
     ],
     "top": "top",
-    "name": "litex-linux",
+    "name": "baselitex",
     "data": [
         "src/baselitex/mem.init",
         "src/baselitex/mem_1.init",

--- a/project/picorv32.json
+++ b/project/picorv32.json
@@ -4,7 +4,7 @@
         "src/picorv32/picorv32_wrap.v"
     ],
     "top": "top",
-    "name": "picorv32-wrap",
+    "name": "picorv32",
     "clocks": {
         "clk": 10.0
     },

--- a/project/picosoc-simpleuart.json
+++ b/project/picosoc-simpleuart.json
@@ -4,7 +4,7 @@
         "src/picosoc-simpleuart/picosoc_simpleuart_wrap.v"
     ],
     "top": "top",
-    "name": "picosoc-simpleuart-wrap",
+    "name": "picosoc-simpleuart",
     "clocks": {
         "clk": 10.0
     },

--- a/project/picosoc-spimemio.json
+++ b/project/picosoc-spimemio.json
@@ -4,7 +4,7 @@
         "src/picosoc-spimemio/picosoc_spimemio_wrap.v"
     ],
     "top": "top",
-    "name": "picosoc-spimemio-wrap",
+    "name": "picosoc-spimemio",
     "clocks": {
         "clk": 10.0
     },

--- a/project/picosoc.json
+++ b/project/picosoc.json
@@ -8,7 +8,7 @@
         "src/picosoc/progmem.v"
     ],
     "top": "top",
-    "name": "picosoc-wrap",
+    "name": "picosoc",
     "clocks": {
         "clk": 10.0
     },

--- a/project/vexriscv.json
+++ b/project/vexriscv.json
@@ -4,7 +4,7 @@
         "src/vexriscv/vexriscv-verilog_wrap.v"
     ],
     "top": "top",
-    "name": "vexriscv-verilog",
+    "name": "vexriscv",
     "clocks": {
         "clk": 10.0
     },

--- a/radiant.py
+++ b/radiant.py
@@ -78,7 +78,7 @@ class RadiantLSE(Radiant):
 
     def __init__(self):
         Radiant.__init__(self)
-        self.toolchain = 'radiant-lse'
+        self.toolchain = 'lse-radiant'
 
     def syn(self):
         return "lse"
@@ -90,7 +90,7 @@ class RadiantSynpro(Radiant):
 
     def __init__(self):
         Radiant.__init__(self)
-        self.toolchain = 'radiant-synpro'
+        self.toolchain = 'synpro-radiant'
 
     def syn(self):
         return "synplify"
@@ -103,7 +103,7 @@ class RadiantYosys(Radiant):
 
     def __init__(self):
         Radiant.__init__(self)
-        self.toolchain = 'radiant-yosys'
+        self.toolchain = 'yosys-radiant'
 
     def syn(self):
         return "yosys-synpro"

--- a/vivado.py
+++ b/vivado.py
@@ -235,7 +235,7 @@ class VivadoYosys(Vivado):
         Vivado.__init__(self, rootdir)
         self.synthtool = 'yosys'
         self.synthoptions = ['-iopad', '-arch xc7', '-flatten']
-        self.toolchain = 'vivado-yosys'
+        self.toolchain = 'yosys-vivado'
 
     @staticmethod
     def check_env():

--- a/vivado.py
+++ b/vivado.py
@@ -235,7 +235,7 @@ class VivadoYosys(Vivado):
         Vivado.__init__(self, rootdir)
         self.synthtool = 'yosys'
         self.synthoptions = ['-iopad', '-arch xc7', '-flatten']
-        self.toolchain = 'yosys-vivado'
+        self.toolchain = 'vivado-yosys'
 
     @staticmethod
     def check_env():


### PR DESCRIPTION
There was an issue with `exhaust.py` runs, which would print the stats of all of the saved builds, even if only a certain project or toolchain was specifically being tested like in running `python3 exhaust.py --toolchain vivado-yosys`.

This pull request fixes this by adding conditions to only print the runs that match the specified toolchain and project arguments, just as the condition to only print runs of the specified build name and number already exists.

I also fixed the names of the `vivado-yosys` toolchain and many of the projects to match the names that the user inputs to run them. Odd to run the `vivado-yosys` toolchain and then have it called the `yosys-vivado` toolchain in the build summary. Naming the synthesis tool after the primary tool seems to match the rest of the toolchain names too. This consistency also matters for the implementation of filtering the results printed.