### PR TITLE
tools: pin nextpnr-xilinx and fasm2bels

### DIFF
--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - symbiflow-yosys=0.8_6021_gd8b2d1a2
   - symbiflow-yosys-plugins=1.0.0.7_0048_gaa1b583
   - symbiflow-vtr=8.0.0.rc2_4003_g8980e4621
-  - nextpnr-xilinx
+  - nextpnr-xilinx=0.0_2809_g7e46c6a3
   - nextpnr-ice40
   - prjxray-tools
   - prjxray-db=0.0_0230_g485a837

--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -13,4 +13,4 @@ yapf
 git+https://github.com/SymbiFlow/fasm.git#egg=fasm
 git+https://github.com/SymbiFlow/xc-fasm.git#egg=xc-fasm
 git+https://github.com/SymbiFlow/edalize.git@symbiflow#egg=edalize
-git+https://github.com/SymbiFlow/symbiflow-xc-fasm2bels.git#egg=symbiflow-xc-fasm2bels
+git+https://github.com/SymbiFlow/symbiflow-xc-fasm2bels.git@50cbdb54785962d6009d71c692e9b0af0e80c223#egg=symbiflow-xc-fasm2bels


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This is to have green CI until https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1626 is merged and we can have an updated install package with the correct fasm features