### PR TITLE
vpr: update overhead calculation

### DIFF
--- a/symbiflow.py
+++ b/symbiflow.py
@@ -22,9 +22,12 @@ class VPR(Toolchain):
 
     def run_steps(self):
         self.backend.build_main(self.top + '.eblif')
-        self.backend.build_main(self.top + '.net')
-        self.backend.build_main(self.top + '.place')
-        self.backend.build_main(self.top + '.route')
+        with Timed(self, 'pack_all', unprinted_runtime=True):
+            self.backend.build_main(self.top + '.net')
+        with Timed(self, 'place_all', unprinted_runtime=True):
+            self.backend.build_main(self.top + '.place')
+        with Timed(self, 'route_all', unprinted_runtime=True):
+            self.backend.build_main(self.top + '.route')
         self.backend.build_main(self.top + '.fasm')
         with Timed(self, 'bitstream'):
             self.backend.build_main(self.top + '.bit')
@@ -377,21 +380,12 @@ class VPR(Toolchain):
                     if '{} took'.format(step) in l:
                         return float(l.split()[position])
 
-        def get_overhead_runtime(logfile):
-            steps = [
-                'Clean circuit took', 'Load Timing Constraints took',
-                'Create Device took'
-            ]
-            overhead = 0.0
-            with open(logfile, 'r') as fp:
-                for l in fp:
-                    l = l.strip()
-                    for step in steps:
-                        if step in l:
-                            overhead += float(
-                                l.split()[l.split().index('took') + 1]
-                            )
-            return overhead
+        def get_overhead_runtime(name, log):
+            if name in log and "%s_all" % name in self.unprinted_runtimes:
+                if 'overhead' not in log:
+                    log['overhead'] = 0.0
+                log['overhead'] += self.unprinted_runtimes["%s_all" % name
+                                                           ] - log[name]
 
         log = dict()
 
@@ -401,14 +395,15 @@ class VPR(Toolchain):
         fasm_log = os.path.join(self.out_dir, 'fasm.log')
 
         log['pack'] = get_step_runtime('Packing', pack_log, 3)
-        log['overhead'] = get_overhead_runtime(pack_log)
         log['place'] = get_step_runtime('Placement', place_log, 3)
-        log['overhead'] += get_overhead_runtime(place_log)
         log['route'] = get_step_runtime('Routing', route_log, 3)
-        log['overhead'] += get_overhead_runtime(route_log)
         # XXX: Need add to genfasm the amount of time it took to create the fasm file.
         #      For now the whole command execution time is considered
         log['fasm'] = get_step_runtime('The entire flow of VPR', fasm_log, 6)
+
+        get_overhead_runtime("pack", log)
+        get_overhead_runtime("place", log)
+        get_overhead_runtime("route", log)
 
         return log
 

--- a/toolchain.py
+++ b/toolchain.py
@@ -21,6 +21,7 @@ class Toolchain:
     def __init__(self, rootdir):
         self.rootdir = rootdir
         self.runtimes = collections.OrderedDict()
+        self.unprinted_runtimes = collections.OrderedDict()
         self.toolchain = None
         self.verbose = False
         self.cmds = []
@@ -72,16 +73,18 @@ class Toolchain:
             tokens.append('seed-%08X' % (self.seed, ))
         return '_'.join(tokens)
 
-    def add_runtime(self, name, dt, parent=None):
+    def add_runtime(self, name, dt, parent=None, unprinted_runtime=False):
+        collection = self.runtimes
+        if unprinted_runtime:
+            collection = self.unprinted_runtimes
         if parent is None:
-            self.runtimes[name] = dt
+            collection[name] = dt
         else:
-            assert (parent not in self.runtimes) or (
-                type(self.runtimes[parent]) is collections.OrderedDict
-            )
-            if parent not in self.runtimes:
-                self.runtimes[parent] = collections.OrderedDict()
-            self.runtimes[parent][name] = dt
+            assert (parent not in collection
+                    ) or (type(collection[parent]) is collections.OrderedDict)
+            if parent not in collection:
+                collection[parent] = collections.OrderedDict()
+            collection[parent][name] = dt
 
     def design(self):
         ret = "{}_{}_{}_{}_{}".format(

--- a/utils.py
+++ b/utils.py
@@ -3,17 +3,22 @@ import os
 
 
 class Timed:
-    def __init__(self, t, name):
+    def __init__(self, t, name, unprinted_runtime=False):
         self.t = t
         self.name = name
         self.start = None
+        self.unprinted_runtime = unprinted_runtime
 
     def __enter__(self):
         self.start = time.time()
 
     def __exit__(self, type, value, traceback):
         end = time.time()
-        self.t.add_runtime(self.name, end - self.start)
+        self.t.add_runtime(
+            self.name,
+            end - self.start,
+            unprinted_runtime=self.unprinted_runtime
+        )
 
 
 def get_vivado_max_freq(report_file):


### PR DESCRIPTION
Update overhead calculation for vpr to `total step run` - `useful step work`.

This PR also adds possibility to calculate time with `Timed` class without automatic adding it to printable `runtimes` collection.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>