### PR TITLE
Add vendors key to bram 1, 2, 3 and dram projects

### DIFF
--- a/project/bram_n1.json
+++ b/project/bram_n1.json
@@ -21,5 +21,6 @@
         "vivado-yosys": {
             "basys3": ["basys3.xdc"]
         }
-    }
+    },
+    "vendors": ["xilinx"]
 }

--- a/project/bram_n2.json
+++ b/project/bram_n2.json
@@ -24,5 +24,6 @@
         "vivado-yosys": {
             "basys3": ["basys3.xdc"]
         }
-    }
+    },
+    "vendors": ["xilinx"]
 }

--- a/project/bram_n3.json
+++ b/project/bram_n3.json
@@ -24,5 +24,6 @@
         "vivado-yosys": {
             "basys3": ["basys3.xdc"]
         }
-    }
+    },
+    "vendors": ["xilinx"]
 }

--- a/project/dram_test_64x1d.json
+++ b/project/dram_test_64x1d.json
@@ -30,5 +30,6 @@
         "vivado-yosys": {
             "basys3": ["basys3.xdc"]
         }
-    }
+    },
+    "vendors": ["xilinx"]
 }


### PR DESCRIPTION
Add missing vendor key to bram 1, 2, 3 and dram projects. This key is required for `--list-combinations`.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>