### PR TITLE
Exhaust `--overwrite` argument

### DIFF
--- a/exhaust.py
+++ b/exhaust.py
@@ -131,6 +131,11 @@ def main():
     parser.add_argument(
         '--verbose', action='store_true', help='verbose output'
     )
+    parser.add_argument(
+        '--overwrite',
+        action='store_true',
+        help='deletes previous exhuast builds before running'
+    )
 
     args = parser.parse_args()
 
@@ -191,7 +196,7 @@ def main():
 
     runner = Runner(
         task_list, args.verbose, args.out_prefix, root_dir, args.build_type,
-        build_numbers
+        build_numbers, args.overwrite
     )
 
     logger.debug("Running Projects")

--- a/runner.py
+++ b/runner.py
@@ -29,7 +29,7 @@ class Runner:
     """
     def __init__(
         self, task_list, verbose, out_prefix, root_dir, build_type,
-        build_numbers
+        build_numbers, overwrite
     ):
         self.verbose = verbose
         self.out_prefix = out_prefix
@@ -39,6 +39,7 @@ class Runner:
         self.results = dict()
         self.task_list = task_list
         self.build_numbers = build_numbers
+        self.overwrite = overwrite
 
     def worker(self, arglist):
         """Single worker function that is run in the Pool of workers.
@@ -64,7 +65,7 @@ class Runner:
                     option,  #params_string
                     None,  #out_dir
                     self.out_prefix,
-                    False,  #overwrite
+                    self.overwrite,
                     self.verbose,
                     None,  #strategy
                     seed,


### PR DESCRIPTION
Added an argument that overwrites previous builds to re-run any builds that previously existed. Where it would previously give False for 'overwrite' when calling the fpgaperf run function, now it provides self.overwrite, which is true if --overwrite is specified in the command and false otherwise.