### PR TITLE
Exhaust Task List Generation

### DIFF
--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -351,6 +351,12 @@ def env_ready():
     return True
 
 
+def verify_constraint(project, board, extension):
+    board_file = board + "." + extension
+    path = os.path.join(src_dir, project, 'constr', board_file)
+    return os.path.exists(path)
+
+
 def get_constraint(project, board, constr_list, extension):
     constr_file = [v for v in constr_list if v.endswith(extension)]
 

--- a/other/vendors.json
+++ b/other/vendors.json
@@ -1,7 +1,7 @@
 {
     "xilinx": {
         "boards": ["arty", "basys3", "zybo", "nexys"],
-        "toolchains": ["vivado", "vivado-yosys", "vpr", "vpr-fasm2bels", "nextpnr-xilinx", "nextpnr-xilinx-fasm2bels"]
+        "toolchains": ["vivado", "yosys-vivado", "vpr", "vpr-fasm2bels", "nextpnr-xilinx", "nextpnr-xilinx-fasm2bels"]
     },
     "lattice": {
         "boards": ["icebreaker", "tinyfpgab2"],

--- a/tasks.py
+++ b/tasks.py
@@ -12,7 +12,7 @@
 import os
 from itertools import product
 
-from fpgaperf import get_projects, get_project, get_toolchains, get_constraint
+from fpgaperf import get_projects, get_project, get_toolchains, get_constraint, get_vendors
 
 
 class Tasks:
@@ -37,43 +37,29 @@ class Tasks:
         """Returns all the possible combination of:
             - projects,
             - toolchains,
-            - families,
-            - devices,
-            - packages
             - boards.
 
         Example:
-        - path structure:    src/<project>/<toolchain>/<family>_<device>_<package>_<board>.<constraint>
-        - valid combination: src/oneblink/vpr/xc7_a35t_csg324-1_arty.pcf
+        - path structure:    src/<project>/constr/<board>.<constraint>
+        - valid combination: src/oneblink/constr/arty.pcf
         """
 
-        projects = get_projects()
-        toolchains = get_toolchains()
+        new_combinations = set()
 
-        combinations = set()
-        for project, toolchain in list(product(projects, toolchains)):
+        vendors = get_vendors()
+        for project in get_projects():
             project_dict = get_project(project)
+            
+            for vendor in project_dict["vendors"]:
+                toolchains = vendors[vendor]["toolchains"]
+                boards = vendors[vendor]["boards"]
 
-            if 'toolchains' in project_dict:
-                toolchains_dict = project_dict['toolchains']
-            else:
-                continue
+                for toolchain, board in list(product(toolchains, boards)):
+                    new_combinations.add((project, toolchain, board))
+                    
+        ### Update: Specifically use only those with the files ready
 
-            if toolchain not in toolchains_dict:
-                continue
-
-            if toolchain not in self.MANDATORY_CONSTRAINTS.keys():
-                continue
-
-            for board in toolchains_dict[toolchain]:
-                assert get_constraint(
-                    project, board, toolchains_dict[toolchain][board],
-                    self.MANDATORY_CONSTRAINTS[toolchain]
-                )
-
-                combinations.add((project, toolchain, board))
-
-        return combinations
+        return new_combinations
 
     def get_tasks(self, args, seeds=[0], build_number=[0], options=[None]):
         """Returns all the tasks filtering out the ones that do not correspond
@@ -99,7 +85,8 @@ class Tasks:
         tasks = self.add_extra_entry(
             build_number, tasks, create_new_tasks=True
         )
-
+        for task in tasks:
+            print(task)
         return tasks
 
     def add_extra_entry(

--- a/tasks.py
+++ b/tasks.py
@@ -21,15 +21,6 @@ class Tasks:
     def __init__(self, root_dir):
         self.root_dir = root_dir
         self.src_dir = os.path.join(root_dir, 'src')
-        self.MANDATORY_CONSTRAINTS = {
-            "vivado": "xdc",
-            "vpr": "pcf",
-            "vpr-fasm2bels": "pcf",
-            "yosys-vivado": "xdc",
-            "nextpnr-xilinx": "xdc",
-            "nextpnr-xilinx-fasm2bels": "xdc",
-            "nextpnr-ice40": "pcf",
-        }
 
         self.tasks = self.iter_options()
 
@@ -56,10 +47,7 @@ class Tasks:
 
                 for toolchain, board in list(product(toolchains, boards)):
 
-                    if verify_constraint(
-                            project, board,
-                            self.MANDATORY_CONSTRAINTS[toolchain]):
-                        combinations.add((project, toolchain, board))
+                    combinations.add((project, toolchain, board))
 
         return combinations
 


### PR DESCRIPTION
These reflect changes requested by @acomodi and has to do with issue #215.

These are simply some initial changes and not ready to be merged. I would like some feedback and then discussion on how to modify or continue this work in relation to #214 and #215

exhaust.py is in fact functional (though it doesn't pass the kokoro tests) with the changes I have made so far. It seems like this will allow us to remove the toolchain specs within `project` files as soon as toolchains become functional with all projects and fpgaperf.py's code is updated. Also only tests the projects whose constr file names are simply "board.extension" (e.g. basys3.xdc, arty.pcf).

Now relies on the vendor specs in each project file, mostly to keep certain board and toolchain combos clear of one another.