### PR TITLE
Exhaust Results Improvements

### DIFF
--- a/exhaust.py
+++ b/exhaust.py
@@ -100,8 +100,9 @@ def print_summary_table(
 
     table_data.append(
         [
+            Color('{autoblue}Total Runs:{/autoblue}'), build_count,
             Color('{autogreen}Passed:{/autogreen}'), passed,
-            Color('{autored}Failed:{/autored}'), failed, '', '', '', '', '{}%'.
+            Color('{autored}Failed:{/autored}'), failed, '', '', '{}%'.
             format(int(passed / build_count * 100) if build_count != 0 else 0)
         ]
     )


### PR DESCRIPTION
Most changes originally made by this PR are either implemented by or made irrelevant by recent commits. However, I still think it would be nice for the "Total Runs:" statement to be there just for further clarity, especially in cases where there aren't any actual runs, but a table is still printed.
```
$ python3 exhaust.py --toolchain nextpnr-ice40 --project oneblink
100%|████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.51s/test]
+-------------+---------------+---------+----------+------------+------------+----------+-------------+--------+
| Project     | Toolchain     | Family  | Part     | Board      | Build Type | Build N. | Options     |        |
+-------------+---------------+---------+----------+------------+------------+----------+-------------+--------+
| oneblink    | nextpnr-ice40 | ice40   | up5ksg48 | icebreaker | generic    | 000      | pcf_carry-y | passed |
+-------------+---------------+---------+----------+------------+------------+----------+-------------+--------+
| Total Runs: | 1             | Passed: | 1        | Failed:    | 0          |          |             | 100%   |
+-------------+---------------+---------+----------+------------+------------+----------+-------------+--------+
$
$ python3 exhaust.py --toolchain vpr --project blinky --board nexys
Writing to build/_exhaust-runs
0test [00:00, ?test/s]
+-------------+-----------+---------+------+---------+------------+----------+---------+----+
| Project     | Toolchain | Family  | Part | Board   | Build Type | Build N. | Options |    |
+-------------+-----------+---------+------+---------+------------+----------+---------+----+
| Total Runs: | 0         | Passed: | 0    | Failed: | 0          |          |         | 0% |
+-------------+-----------+---------+------+---------+------------+----------+---------+----+
```