### PR TITLE
Enable bram_n1 vivado test

### DIFF
--- a/project/bram_n1.json
+++ b/project/bram_n1.json
@@ -12,6 +12,9 @@
         "clk": 10.0
     },
     "toolchains": {
+	"vivado": {
+            "basys3": ["basys3.xdc"]
+	},
         "vpr": {
             "basys3": ["basys3.xdc", "basys3.sdc"]
         },

--- a/src/bram/scalable_proc.v
+++ b/src/bram/scalable_proc.v
@@ -45,7 +45,7 @@ wire [31:0] inp_sreg_i_dat = rom_o_dat;
 reg         inp_sreg_o_stb;
 
 always @(posedge CLK)
-    if (inp_sreg_i_stb) inp_sreg <= {inp_sreg[SREG_BITS-32-1:0], inp_sreg_i_dat};
+    if (inp_sreg_i_stb) inp_sreg <= (NUM_PROCESSING_UNITS > 1) ? {inp_sreg[SREG_BITS-32-1:0], inp_sreg_i_dat} : inp_sreg_i_dat;
     else                inp_sreg <=  inp_sreg;
 
 always @(posedge CLK or posedge RST)


### PR DESCRIPTION
This PR fixes problem with shift register when NUM_PROCESSING_UNITS==1 and enables bram_n1 vivado test.

Fixes #193 
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>