### PR TITLE
symbiflow: fix bram calculation

### DIFF
--- a/symbiflow.py
+++ b/symbiflow.py
@@ -418,6 +418,8 @@ class VPR(Toolchain):
             bram += res['RAMB18E1_Y0']
         if 'RAMB18E1_Y1' in res:
             bram += res['RAMB18E1_Y1']
+        if 'RAMB36E1' in res:
+            bram += res['RAMB36E1'] * 2
         if 'PLLE2_ADV' in res:
             pll = res['PLLE2_ADV']
 
@@ -817,6 +819,8 @@ class NextpnrXilinx(Toolchain):
             iob = iob + res['PAD']
         if 'RAMB18E1_RAMB18E1' in res:
             bram = res['RAMB18E1_RAMB18E1']
+        if 'RAMB36E1_RAMB36E1' in res:
+            bram += res['RAMB36E1_RAMB36E1'] * 2
         if 'PLLE2_ADV_PLLE2_ADV' in res:
             pll = res['PLLE2_ADV_PLLE2_ADV']
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

For symbiflow targets, RAMB36 were not taken into account in the resource usage extraction.

Moreover, each RAMB36 will count as double, as underneath, it uses two RAMB18