### PR TITLE
conda: allow using an external environment file

### DIFF
--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -76,10 +76,16 @@ echo "Setting up conda environment"
 echo "----------------------------------------"
 (
 	echo
+	echo " Installing symbiflow and quicklogic"
+	echo "----------------------------------------"
+	make install_symbiflow
+	make install_quicklogic
+	echo "----------------------------------------"
+
+	echo
 	echo " Configuring conda environment"
 	echo "----------------------------------------"
 	TOOLCHAIN=symbiflow make env
-	TOOLCHAIN=symbiflow-a200t make env
 	TOOLCHAIN=quicklogic make env
 	TOOLCHAIN=nextpnr make env
 	echo "----------------------------------------"

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ install_symbiflow:
 	mkdir -p env/symbiflow
 	wget -O ${SYMBIFLOW_ARCHIVE} ${SYMBIFLOW_URL}
 	tar -xf ${SYMBIFLOW_ARCHIVE} -C env/symbiflow
+	wget -O ${SYMBIFLOW_ARCHIVE} ${SYMBIFLOW_URL_200T}
+	tar -xf ${SYMBIFLOW_ARCHIVE} -C env/symbiflow
 	rm ${SYMBIFLOW_ARCHIVE}
 	# Adapt the environment file from symbiflow-arch-defs
 	test -e env/symbiflow/environment.yml && sed -i 's/symbiflow_arch_def_base/symbiflow-env/g' env/symbiflow/environment.yml || true

--- a/Makefile
+++ b/Makefile
@@ -17,25 +17,15 @@ all: format
 
 TOP_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 TOOLCHAIN ?= symbiflow
-TOOLCHAIN_LOCATION ?= symbiflow
-REQUIREMENTS_FILE := conf/${TOOLCHAIN}/requirements.txt
-ENVIRONMENT_FILE := conf/${TOOLCHAIN}/environment.yml
+REQUIREMENTS_FILE ?= conf/${TOOLCHAIN}/requirements.txt
+ENVIRONMENT_FILE ?= conf/${TOOLCHAIN}/environment.yml
 
-SYMBIFLOW_ARCHIVE = ${TOOLCHAIN}.tar.xz
 # FIXME: make this dynamic: https://github.com/SymbiFlow/fpga-tool-perf/issues/75
-SYMBIFLOW_URL = "https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/80/20201020-195452/symbiflow-arch-defs-install-2f55fb8f.tar.xz"
-ifeq ("${TOOLCHAIN}", "symbiflow-a200t")
-SYMBIFLOW_URL = "https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install-200t/23/20201020-195721/symbiflow-arch-defs-install-200t-2f55fb8f.tar.xz"
-REQUIREMENTS_FILE = conf/symbiflow/requirements.txt
-ENVIRONMENT_FILE = conf/symbiflow/environment.yml
-endif
-ifeq ("${TOOLCHAIN}", "quicklogic")
-SYMBIFLOW_URL = https://quicklogic-my.sharepoint.com/:u:/p/kkumar/EWuqtXJmalROpI2L5XeewMIBRYVCY8H4yc10nlli-Xq79g?download=1
-TOOLCHAIN_LOCATION = quicklogic
-endif
-ifeq ("${TOOLCHAIN}", "nextpnr")
-TOOLCHAIN_LOCATION = nextpnr
-endif
+SYMBIFLOW_ARCHIVE = symbiflow.tar.xz
+SYMBIFLOW_URL = https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/80/20201020-195452/symbiflow-arch-defs-install-2f55fb8f.tar.xz
+SYMBIFLOW_URL_200T = https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install-200t/23/20201020-195721/symbiflow-arch-defs-install-200t-2f55fb8f.tar.xz
+QUICKLOGIC_ARCHIVE = quicklogic.tar.xz
+QUICKLOGIC_URL = https://quicklogic-my.sharepoint.com/:u:/p/kkumar/EWuqtXJmalROpI2L5XeewMIBRYVCY8H4yc10nlli-Xq79g?download=1
 
 third_party/make-env/conda.mk:
 	git submodule init
@@ -44,10 +34,21 @@ third_party/make-env/conda.mk:
 include third_party/make-env/conda.mk
 
 env:: | $(CONDA_ENV_PYTHON)
-	mkdir -p env/${TOOLCHAIN_LOCATION}$(SYMBIFLOW_VERSION)
+
+install_symbiflow:
+	mkdir -p env/symbiflow
 	wget -O ${SYMBIFLOW_ARCHIVE} ${SYMBIFLOW_URL}
-	tar -xf ${SYMBIFLOW_ARCHIVE} -C env/${TOOLCHAIN_LOCATION}$(SYMBIFLOW_VERSION)
+	tar -xf ${SYMBIFLOW_ARCHIVE} -C env/symbiflow
 	rm ${SYMBIFLOW_ARCHIVE}
+	# Adapt the environment file from symbiflow-arch-defs
+	test -e env/symbiflow/environment.yml && sed -i 's/symbiflow_arch_def_base/symbiflow-env/g' env/symbiflow/environment.yml || true
+	cat conf/common/requirements.txt conf/symbiflow/requirements.txt > env/symbiflow/requirements.txt
+
+install_quicklogic:
+	mkdir -p env/quicklogic
+	wget -O ${QUICKLOGIC_ARCHIVE} ${QUICKLOGIC_URL}
+	tar -xf ${QUICKLOGIC_ARCHIVE} -C env/quicklogic
+	rm ${QUICKLOGIC_ARCHIVE}
 
 run-tests:
 	@$(IN_CONDA_ENV) python3 exhaust.py --build_type generic-all --fail

--- a/env.sh
+++ b/env.sh
@@ -12,21 +12,14 @@ if [ -z "${FPGA_TOOL_PERF_BASE_DIR}" ]; then
     export FPGA_TOOL_PERF_BASE_DIR=$(pwd)
 fi
 if [ -z "${VIVADO_SETTINGS}" ]; then
-    echo "WARNING: using default vivado settings"
     #FIXME: to use the conda xilinx-vivado virtual package when available
     export VIVADO_SETTINGS=/opt/Xilinx/Vivado/2017.2/settings64.sh
 fi
 if [ -z "${SYMBIFLOW}" ]; then
-    echo "WARNING: using default symbiflow dir."
     export SYMBIFLOW=${FPGA_TOOL_PERF_BASE_DIR}/env/symbiflow
 fi
 if [ -z "${QUICKLOGIC}" ]; then
-    echo "WARNING: using default quicklogic dir."
     export QUICKLOGIC=${FPGA_TOOL_PERF_BASE_DIR}/env/quicklogic
-fi
-if [ -z "${NEXTPNR}" ]; then
-    echo "WARNING: using default nextpnr dir."
-    export NEXTPNR=${FPGA_TOOL_PERF_BASE_DIR}/env/nextpnr
 fi
 
 #https://unix.stackexchange.com/a/291611
@@ -40,7 +33,6 @@ function path_remove {
 #Remove all possible paths from PATH
 path_remove ${SYMBIFLOW}/bin
 path_remove ${QUICKLOGIC}/install/bin
-path_remove ${NEXTPNR}/bin
 
 #Set now environment variables
 environment=${1:-xilinx-a35t}
@@ -50,7 +42,7 @@ if [ "quicklogic" == ${environment} ]; then
     export PATH=${QUICKLOGIC}/install/bin:${PATH}
 elif [ "nextpnr" == ${environment} ]; then
     . ${FPGA_TOOL_PERF_BASE_DIR}/env/conda/bin/activate nextpnr-env
-    export PATH=${NEXTPNR}/bin:${PATH}
+    export PATH=${SYMBIFLOW}/bin:${PATH}
 else
     . ${FPGA_TOOL_PERF_BASE_DIR}/env/conda/bin/activate symbiflow-env
     export SYMBIFLOW=${FPGA_TOOL_PERF_BASE_DIR}/env/symbiflow


### PR DESCRIPTION
This PR allows to use a different environment file for conda. Once we have archdefs producing "latest" artifacts links, we can start having automated updates on the symbiflow packages, based on the symbiflow-arch-defs updates.

It also reworks the way symbiflow and quicklogic data files are downloaded and installed.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>