### PR TITLE
nextpnr-env: use same yosys and yosys-plugins as symbiflow-env

### DIFF
--- a/conf/nextpnr/environment.yml
+++ b/conf/nextpnr/environment.yml
@@ -3,9 +3,10 @@ channels:
   - defaults
   - symbiflow
 dependencies:
+  - symbiflow-yosys=0.8_6021_gd8b2d1a2=20200708_083630
+  - symbiflow-yosys-plugins=1.0.0.7_0174_g5e6370a=20201012_171341
   - symbiflow-vtr=8.0.0.rc2_5097_gf1a3bcc2a
   - nextpnr-xilinx=0.0_2814_gd40ffba7
-  - symbiflow-yosys-plugins=1.0.0.7_0117_g160b309
   - libboost=1.73.0
   - nextpnr-ice40
   - prjxray-db


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>