### PR TITLE
quicklogic: Use Conda packages from LiteX-Hub channel

### DIFF
--- a/conf/quicklogic/environment.yml
+++ b/conf/quicklogic/environment.yml
@@ -1,11 +1,11 @@
 name: quicklogic
 channels:
   - conda-forge
-  - quicklogic-corp/label/ql
+  - litex-hub
 dependencies:
-  - yosys=0.5_7972_g4045d484=20200817_053125
-  - yosys-plugins=1.2.0_0009_g9ab211c=20200817_053125
-  - vtr=v8.0.0_rc2_4003_g8980e4621=20200817_053125
+  - litex-hub::quicklogic-yosys=v0.8.0_45_gcb3eef2b=20201216_065815
+  - litex-hub::quicklogic-yosys-plugins=v1.2.0_11_g21045a9=20201216_065815
+  - litex-hub::quicklogic-vtr=v8.0.0.rc2_4003_g8980e4621=20200902_114536
   - make
   - lxml
   - simplejson


### PR DESCRIPTION
`quicklogic-vtr` had to stay at the same version because testing on
`symbiflow-examples` showed that newer versions are incompatible with
the currently used quicklogic toolchain.

Other packages are in the versions built from their latest source
commits.