### PR TITLE
Fixed --check-env Functionality

### DIFF
--- a/toolchains/fasm2bels.py
+++ b/toolchains/fasm2bels.py
@@ -16,7 +16,7 @@ import edalize
 
 from toolchains.toolchain import Toolchain
 from toolchains.symbiflow import VPR, NextpnrXilinx
-from utils.utils import Timed, get_vivado_max_freq, which
+from utils.utils import Timed, get_vivado_max_freq, which, have_exec
 
 
 class VPRFasm2Bels(VPR):

--- a/toolchains/icecube.py
+++ b/toolchains/icecube.py
@@ -12,7 +12,7 @@
 import os
 
 from toolchains.toolchain import Toolchain
-from utils.utils import Timed
+from utils.utils import Timed, have_exec
 
 
 # no seed support?

--- a/toolchains/icestorm.py
+++ b/toolchains/icestorm.py
@@ -23,7 +23,7 @@ import asciitable
 import edalize
 
 from toolchains.toolchain import Toolchain
-from utils.utils import Timed
+from utils.utils import Timed, have_exec
 
 
 class Icestorm(Toolchain):

--- a/toolchains/radiant.py
+++ b/toolchains/radiant.py
@@ -12,7 +12,7 @@
 import os
 
 from toolchains.toolchain import Toolchain
-from utils.utils import Timed
+from utils.utils import Timed, have_exec
 
 
 # .asc version field just says "DiamondNG"

--- a/toolchains/toolchain.py
+++ b/toolchains/toolchain.py
@@ -21,7 +21,7 @@ import glob
 import datetime
 import shutil
 
-from utils.utils import Timed
+from utils.utils import Timed, have_exec
 
 
 class Toolchain:


### PR DESCRIPTION
Something got moved preventing --check-env working for certain toolchains. This was easily fixed by importing have_exec to those toolchain's python files.