### PR TITLE
tests: add a zynq counter test that uses the PS7

### DIFF
--- a/project/zynq-ps7-counter.json
+++ b/project/zynq-ps7-counter.json
@@ -1,0 +1,14 @@
+{
+    "srcs": [
+        "src/zynq-ps7-counter/counter_zynq.v"
+        ],
+    "top": "top",
+    "name": "zynq-ps7-counter",
+    "clocks": {
+        "clk": 12.5
+    },
+    "vendors": {
+        "xilinx": ["zybo"]
+    },
+    "required_toolchains": ["vivado", "yosys-vivado", "nextpnr-xilinx", "nextpnr-xilinx-fasm2bels", "vpr", "vpr-fasm2bels"]
+}

--- a/src/zynq-ps7-counter/constr/zybo.xdc
+++ b/src/zynq-ps7-counter/constr/zybo.xdc
@@ -1,0 +1,16 @@
+# Clock pin
+set_property LOC K17 [get_ports {clk}]
+set_property IOSTANDARD LVCMOS33 [get_ports {clk}]
+
+# LEDs
+set_property LOC M14 [get_ports {led[0]}]
+set_property LOC M15 [get_ports {led[1]}]
+set_property LOC G14 [get_ports {led[2]}]
+set_property LOC D18 [get_ports {led[3]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[1]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[2]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[3]}]
+
+# Clock constraints
+create_clock -period 10.0 [get_ports {clk}]

--- a/src/zynq-ps7-counter/counter_zynq.v
+++ b/src/zynq-ps7-counter/counter_zynq.v
@@ -1,0 +1,36 @@
+module top(
+    input  wire clk,
+    output wire [3:0] led
+);
+
+wire [63:0] emio_gpio_o;
+wire [63:0] emio_gpio_t;
+wire [63:0] emio_gpio_i;
+
+wire clk_bufg;
+BUFG BUFG(.I(clk), .O(clk_bufg));
+
+wire en_counter = ~emio_gpio_o[0];
+wire count_direction = ~emio_gpio_o[1];
+reg [31:0] counter = 0;
+
+always @(posedge clk_bufg) begin
+    if (en_counter)
+        if (count_direction)
+            counter <= counter + 1;
+        else
+            counter <= counter - 1;
+end
+
+assign led = counter[27:24];
+
+// The PS7
+(* KEEP, DONT_TOUCH *)
+PS7 PS7(
+    .EMIOGPIOO                  (emio_gpio_o),
+    .EMIOGPIOTN                 (emio_gpio_t),
+    .EMIOGPIOI                  (emio_gpio_i)
+);
+
+
+endmodule


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>