### PR TITLE
Add dependencies for FASM ANTLR parser.

### DIFF
--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -63,6 +63,8 @@ sudo apt-get install -y \
         python3-virtualenv \
         python3-yaml \
         virtualenv \
+        default-jre-headless \
+        uuid-dev \
 
 if [ -z "${BUILD_TOOL}" ]; then
     export BUILD_TOOL=make


### PR DESCRIPTION
These Ubuntu packages are required to build the faster ANTLR FASM parser. Without them, the `fasm` package will fall back to the previous parser implementation.

- default-jre-headless
- uuid-dev
