### PR TITLE
make env: update base env with symbiflow environment

### DIFF
--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -85,7 +85,7 @@ echo "----------------------------------------"
 	echo
 	echo " Configuring conda environment"
 	echo "----------------------------------------"
-	ENVIRONMENT_FILE=env/symbiflow/environment.yml TOOLCHAIN=symbiflow make env
+	TOOLCHAIN=symbiflow make env
 	TOOLCHAIN=quicklogic make env
 	TOOLCHAIN=nextpnr make env
 	echo "----------------------------------------"

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,13 @@ include third_party/make-env/conda.mk
 
 env:: | $(CONDA_ENV_PYTHON)
 
-install_symbiflow:
+install_symbiflow: | $(CONDA_ENV_PYTHON)
 	mkdir -p env/symbiflow
 	curl -s ${SYMBIFLOW_LATEST_URL} | xargs wget -qO- | tar -xJC env/symbiflow
 	# Adapt the environment file from symbiflow-arch-defs
 	test -e env/symbiflow/environment.yml && sed -i 's/symbiflow_arch_def_base/symbiflow-env/g' env/symbiflow/environment.yml || true
 	cat conf/common/requirements.txt conf/symbiflow/requirements.txt > env/symbiflow/requirements.txt
+	@$(IN_CONDA_ENV_BASE) conda env update --name symbiflow-env --file env/symbiflow/environment.yml
 	# Install all devices
 	for device in ${SYMBIFLOW_DEVICES}; do \
 		curl -s ${SYMBIFLOW_LATEST_URL_BASE}/symbiflow-$${device}_test-latest | xargs wget -qO- | tar -xJC env/symbiflow; \

--- a/conf/symbiflow/environment.yml
+++ b/conf/symbiflow/environment.yml
@@ -3,16 +3,7 @@ channels:
   - defaults
   - litex-hub
 dependencies:
-  - litex-hub::capnproto-java=0.1.5_0012_g44a8c1e=20201104_165332
-  - litex-hub::gcc-riscv64-elf-newlib=9.2.0=20201119_154229
-  - litex-hub::symbiflow-yosys-plugins=1.0.0_7_g59ff1e6_23_g3a95697_17_g00b887b_0194_g40efa51=20201120_145821
-  - litex-hub::prjxray-tools=0.1_2697_g0f939808=20201120_145821
-  - litex-hub::prjxray-db=0.0_0239_gd87c844=20201120_145821
-  - litex-hub::vtr=v8.0.0_3011_gb0223dc59=20201202_112618
-  - litex-hub::yosys=0.9_5007_g2116c585=20201202_112618
-  # swig is required to build the rapidyaml package
-  # It can be removed once that is available in PyPi
-  - swig
+  - python=3.7
   - pip
   - pip:
     - -r file:../common/requirements.txt


### PR DESCRIPTION
This PR tries to unify created environment between CI and user.
Up to now, kokoro CI was explicitly selecting environment file that is downloaded as part of symbiflow-arch-def (and it was not using ``conf/symbiflow/environment.yml`` at all), but when user follows README there is no information about selecting ``ENVIRONMENT_FILE`` explicitly when creating symbiflow environment, so for user, ``conf/symbiflow/environment.yml`` is used.

This PR changes target ``install_symbiflow`` to first install environment from ``conf/symbiflow/environment.yml`` and then updates it with ``env/symbiflow/environment.yml`` file. This way, we are installing dependencies from both files.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>