### PR TITLE
quicklogic: pin tbb version

### DIFF
--- a/conf/quicklogic/environment.yml
+++ b/conf/quicklogic/environment.yml
@@ -6,6 +6,9 @@ dependencies:
   - litex-hub::quicklogic-yosys=v0.8.0_45_gcb3eef2b=20201216_065815
   - litex-hub::quicklogic-yosys-plugins=v1.2.0_11_g21045a9=20201216_065815
   - litex-hub::quicklogic-vtr=v8.0.0.rc2_4003_g8980e4621=20200902_114536
+  # TODO: remove when quicklogic-vtr will be updated to version built after https://github.com/hdl/conda-eda/pull/90
+  # or when conda-forge will rename API breaking tbb to another name (see https://github.com/conda-forge/tbb-feedstock/issues/81)
+  - tbb=2020.2
   - make
   - lxml
   - simplejson


### PR DESCRIPTION
Related to: https://github.com/SymbiFlow/fpga-tool-perf/pull/317

This PR pins tbb version to fix issue with missing ``libtbb.so.2``.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>