### PR TITLE
Remove directly rapidyaml reference from requirements.

### DIFF
--- a/conf/nextpnr/requirements.txt
+++ b/conf/nextpnr/requirements.txt
@@ -3,8 +3,6 @@ pyyaml
 fasm
 git+https://github.com/SymbiFlow/prjxray.git#egg=prjxray
 git+https://github.com/SymbiFlow/symbiflow-rr-graph.git@951e72f0af1434b785b6617fc8979b413a9909fe#egg=rr-graph
-# TODO: https://github.com/SymbiFlow/python-fpga-interchange/issues/11
-git+https://github.com/litghost/rapidyaml.git@fixup_python_packaging#egg=rapidyaml&subdirectory=api/python
 git+https://github.com/SymbiFlow/python-fpga-interchange.git#egg=python-fpga-interchange
 git+https://github.com/SymbiFlow/xc-fasm.git@e12f31334e96fedf3af86d13cf51f70ad2270f5f#egg=xc-fasm
 git+https://github.com/SymbiFlow/symbiflow-xc-fasm2bels.git@312c53354f18dbf80de91348268221b1da67d9a2#egg=fasm2bels

--- a/conf/symbiflow/requirements.txt
+++ b/conf/symbiflow/requirements.txt
@@ -3,8 +3,6 @@ pyyaml
 fasm
 git+https://github.com/SymbiFlow/prjxray.git#egg=prjxray
 git+https://github.com/SymbiFlow/symbiflow-rr-graph.git#egg=rr-graph
-# TODO: https://github.com/SymbiFlow/python-fpga-interchange/issues/11
-git+https://github.com/litghost/rapidyaml.git@fixup_python_packaging#egg=rapidyaml&subdirectory=api/python
 git+https://github.com/SymbiFlow/python-fpga-interchange.git#egg=python-fpga-interchange
 git+https://github.com/SymbiFlow/xc-fasm.git#egg=xc-fasm
 git+https://github.com/SymbiFlow/symbiflow-xc-fasm2bels.git#egg=fasm2bels


### PR DESCRIPTION
It is no longer required.