### PR TITLE
Merge results in single file

### DIFF
--- a/.github/kokoro/continuous.cfg
+++ b/.github/kokoro/continuous.cfg
@@ -16,7 +16,8 @@ action {
     regex: "**/top_synth.log"
     regex: "**/runme.log"
     regex: "**/yosys.log"
-    strip_prefix: "github/fpga-tool-perf-continuous-test/"
+    regex: "**/results.json"
+    strip_prefix: "github/fpga-tool-perf/"
   }
 }
 

--- a/.github/kokoro/nightly.cfg
+++ b/.github/kokoro/nightly.cfg
@@ -16,7 +16,8 @@ action {
     regex: "**/top_synth.log"
     regex: "**/runme.log"
     regex: "**/yosys.log"
-    strip_prefix: "github/fpga-tool-perf-nightly-test/"
+    regex: "**/results.json"
+    strip_prefix: "github/fpga-tool-perf/"
   }
 }
 

--- a/.github/kokoro/presubmit.cfg
+++ b/.github/kokoro/presubmit.cfg
@@ -16,7 +16,8 @@ action {
     regex: "**/top_synth.log"
     regex: "**/runme.log"
     regex: "**/yosys.log"
-    strip_prefix: "github/fpga-tool-perf-presubmit-test/"
+    regex: "**/results.json"
+    strip_prefix: "github/fpga-tool-perf/"
   }
 }
 

--- a/exhaust.py
+++ b/exhaust.py
@@ -277,8 +277,8 @@ def main():
     logger.debug("Running Projects")
     runner.run()
 
-    logger.debug("Collecting Results")
-    runner.collect_results()
+    logger.debug("Merging results data")
+    runner.merge_results()
 
     logger.debug("Printing Summary Table")
     result, failed_required_tests = print_summary_table(

--- a/infrastructure/runner.py
+++ b/infrastructure/runner.py
@@ -151,6 +151,8 @@ class Runner:
         json_data = dict()
         json_data["date"] = date_str
         json_data["results"] = self.results
-        json_file_path = os.path.join(self.root_dir, self.out_prefix, f'results-{self.build_type}.json')
+        json_file_path = os.path.join(
+            self.root_dir, self.out_prefix, f'results-{self.build_type}.json'
+        )
         with open(json_file_path, "w") as f:
             f.write(json.dumps(json_data, indent=4))

--- a/infrastructure/runner.py
+++ b/infrastructure/runner.py
@@ -9,6 +9,7 @@
 #
 # SPDX-License-Identifier: ISC
 
+import datetime
 import os
 import sys
 import tqdm
@@ -139,3 +140,17 @@ class Runner:
             )
 
         dataframe.to_json(dataframe_path)
+
+    def merge_results(self):
+        for report in self.get_reports():
+            sow.merge(self.results, json.load(open(report, 'r')), ["date"])
+
+        date = datetime.datetime.utcnow()
+        date_str = date.replace(microsecond=0).isoformat()
+
+        json_data = dict()
+        json_data["date"] = date_str
+        json_data["results"] = self.results
+        json_file_path = os.path.join(self.root_dir, self.out_prefix, f'results-{self.build_type}.json')
+        with open(json_file_path, "w") as f:
+            f.write(json.dumps(json_data, indent=4))

--- a/project/baselitex-nexys-video.json
+++ b/project/baselitex-nexys-video.json
@@ -13,6 +13,13 @@
     "clocks": {
         "clk100": 10.0
     },
+    "clock_aliases": {
+        "clk100": ["main_crg_clkin"],
+        "eth_rx_clk": ["main_ethphy_clkin"],
+        "eth_tx_clk": ["main_ethphy_clkout_buf0"],
+        "sys_clk": ["main_crg_clkout0"],
+        "idelay_clk": ["main_crg_clkout_buf3"]
+    },
     "vendors": {
         "xilinx": ["nexys-video"]
     },

--- a/project/baselitex.json
+++ b/project/baselitex.json
@@ -13,6 +13,10 @@
     "clocks": {
         "clk100": 10.0
     },
+    "clock_aliases": {
+        "sys_clk": ["sys_clk", "soc_pll_sys"],
+        "clk200_clk": ["clk200_clk", "soc_pll_clk200"]
+    },
     "vendors": {
         "xilinx": ["arty-a35t", "arty-a100t"]
     },

--- a/project/blinky.json
+++ b/project/blinky.json
@@ -7,6 +7,9 @@
     "clocks": {
         "clk_i": 10.0
     },
+    "clock_aliases": {
+        "clk_i": ["clk"]
+    },
     "vendors": {
         "xilinx": ["arty-a35t", "arty-a100t", "basys3"]
     },

--- a/project/bram-n1.json
+++ b/project/bram-n1.json
@@ -11,6 +11,9 @@
     "clocks": {
         "clk": 10.0
     },
+    "clock_aliases": {
+        "clk": ["scalable_proc.CLK"]
+    },
     "vendors": {
         "xilinx": ["basys3", "nexys-video"]
     },

--- a/project/bram-n2.json
+++ b/project/bram-n2.json
@@ -11,6 +11,9 @@
     "clocks": {
         "clk": 10.0
     },
+    "clock_aliases": {
+        "clk": ["scalable_proc.CLK"]
+    },
     "vendors": {
         "xilinx": ["basys3", "nexys-video"]
     },

--- a/project/bram-n3.json
+++ b/project/bram-n3.json
@@ -11,6 +11,9 @@
     "clocks": {
         "clk": 10.0
     },
+    "clock_aliases": {
+        "clk": ["scalable_proc.CLK"]
+    },
     "vendors": {
         "xilinx": ["basys3", "nexys-video"]
     },

--- a/project/dram-test-64x1d.json
+++ b/project/dram-test-64x1d.json
@@ -14,6 +14,9 @@
     "clocks": {
         "clk": 10.0
     },
+    "clock_aliases": {
+        "clk": ["dram_test.cl"]
+    },
     "vendors": {
         "xilinx": ["basys3", "nexys-video"]
     },

--- a/project/ibex.json
+++ b/project/ibex.json
@@ -29,6 +29,9 @@
     "clocks": {
         "IO_CLK": 10.0
     },
+    "clock_aliases": {
+        "clk_sys": ["clk_50_unbuf", "clkgen.clk_50_unbuf", "u_ram.clk_i", "clk"]
+    },
     "vendors": {
         "xilinx": ["arty-a35t", "arty-a100t", "basys3", "nexys-video"]
     },

--- a/project/murax.json
+++ b/project/murax.json
@@ -14,6 +14,9 @@
     "clocks": {
         "io_mainClk": 10.0
     },
+    "clock_aliases": {
+        "io_mainClk": ["clk", "io_mainClk_bufg"]
+    },
     "vendors": {
         "xilinx": ["basys3", "nexys-video"]
     },

--- a/project/picosoc-simpleuart.json
+++ b/project/picosoc-simpleuart.json
@@ -8,6 +8,9 @@
     "clocks": {
         "clk": 10.0
     },
+    "clock_aliases": {
+        "clk": ["dut.clk"]
+    },
     "vendors": {
         "xilinx": ["arty-a35t", "arty-a100t", "basys3", "zybo", "nexys-video"],
         "lattice": ["icebreaker"],

--- a/project/picosoc.json
+++ b/project/picosoc.json
@@ -12,6 +12,9 @@
     "clocks": {
         "clk": 10.0
     },
+    "clock_aliases": {
+        "clk": ["clk_bufg"]
+    },
     "vendors": {
         "xilinx": ["basys3", "nexys"]
     },

--- a/project/vexriscv.json
+++ b/project/vexriscv.json
@@ -8,6 +8,9 @@
     "clocks": {
         "clk": 10.0
     },
+    "clock_aliases": {
+        "clk": ["dut.clk"]
+    },
     "vendors": {
         "xilinx": ["arty-a35t", "arty-a100t", "basys3", "zybo", "nexys-video"]
     },

--- a/project/zynq-ps7-counter.json
+++ b/project/zynq-ps7-counter.json
@@ -7,6 +7,9 @@
     "clocks": {
         "clk": 12.5
     },
+    "clock_aliases": {
+        "clk": ["clk_bufg"]
+    },
     "vendors": {
         "xilinx": ["zybo"]
     },

--- a/toolchains/fasm2bels.py
+++ b/toolchains/fasm2bels.py
@@ -48,6 +48,11 @@ class VPRFasm2Bels(VPR):
             'capnp-schemas-dir', shell=True
         ).decode('utf-8').strip()
 
+        # FIXME: remove when package from https://github.com/hdl/conda-eda/pull/127 is used
+        capnp_schema_dir = os.path.join(
+            os.path.split(capnp_schema_dir)[0], 'share', 'vtr'
+        )
+
         self.files.append({'name': capnp_schema_dir, 'file_type': 'capnp'})
 
         assert self.dbroot
@@ -86,6 +91,11 @@ class NextpnrXilinxFasm2Bels(NextpnrXilinx):
         capnp_schema_dir = subprocess.check_output(
             'bash -c ". ./env.sh nextpnr && capnp-schemas-dir"', shell=True
         ).decode('utf-8').strip()
+
+        # FIXME: remove when package from https://github.com/hdl/conda-eda/pull/127 is used
+        capnp_schema_dir = os.path.join(
+            os.path.split(capnp_schema_dir)[0], 'share', 'vtr'
+        )
 
         self.files.append({'name': capnp_schema_dir, 'file_type': 'capnp'})
 

--- a/toolchains/icestorm.py
+++ b/toolchains/icestorm.py
@@ -86,9 +86,18 @@ class Icestorm(Toolchain):
 
     def max_freq(self):
         with open(self.out_dir + '/' + self.project_name + '.tim') as f:
-            return float(
+            max_freq = float(
                 "{:03f}".format(self.icetime_parse(f)['max_freq'] / 1e6)
             )
+
+            clk_data = dict()
+            clk_data["actual"] = max_freq
+            clk_data["hold_violation"] = 0.0
+            clk_data["met"] = True
+            clk_data["requested"] = 0.0
+            clk_data["setup_violation"] = 0.0
+
+            return {"clk": clk_data}
 
     def run(self, pnr, args):
         with Timed(self, 'total'):

--- a/toolchains/toolchain.py
+++ b/toolchains/toolchain.py
@@ -322,8 +322,6 @@ class Toolchain:
             for old_clk, new_clk in clocks_to_rename:
                 max_freq[new_clk] = max_freq.pop(old_clk)
 
-
-
         except FileNotFoundError:
             if all:
                 raise

--- a/utils/sow.py
+++ b/utils/sow.py
@@ -12,8 +12,10 @@
 import json
 
 
-def merge(a, b):
+def merge(a, b, exclude_keys=[]):
     for key in b:
+        if key in exclude_keys:
+            continue
         if key in a:
             a[key].append(b[key])
         else:


### PR DESCRIPTION
This PR does the following:

- allows to create a final results file containing all the various `meta.json` files from all builds
- given that different toolchain use different clock naming conventions, a `clock_alias` field can now be used in the project description to unify and correctly group the frequency results under the same clock name for different toolchains.