### PR TITLE
Update yosys-uhdm to use uhdm frontend as a plugin

### DIFF
--- a/conf/symbiflow/environment.yml
+++ b/conf/symbiflow/environment.yml
@@ -2,9 +2,8 @@ name: symbiflow-env
 channels:
   - defaults
   - litex-hub
-  - conda-forge
 dependencies:
-  - litex-hub::yosys-uhdm=0.5_8690_gb7eccab31=20210730_085634_py37
+  - litex-hub::yosys-uhdm=v0.0_93_ga57fae6
   - python=3.7
   - pip
   - pip:

--- a/toolchains/vivado.py
+++ b/toolchains/vivado.py
@@ -114,8 +114,6 @@ class Vivado(Toolchain):
                     'vivado-settings': vivado_settings,
                     'yosys_synth_options': self.synthoptions,
                 }
-                if hasattr(self, 'library_files'):
-                    vivado_options['frontend_options'] = self.library_files
 
                 self.edam = {
                     'files': self.files,
@@ -350,11 +348,3 @@ class VivadoYosysUhdm(VivadoYosys):
             )
             sys.exit(1)
         uhdm_yosys_path = os.path.dirname(uhdm_yosys_path)
-
-        self.library_files = [
-            "-v " + os.path.join(
-                uhdm_yosys_path,
-                "../share/uhdm-yosys/xilinx/cells_xtra_surelog.v"
-            ), "-v" + os.path.
-            join(uhdm_yosys_path, "../share/uhdm-yosys/xilinx/cells_sim.v")
-        ]


### PR DESCRIPTION
- [x] Requires: https://github.com/SymbiFlow/fpga-tool-perf/pull/338
- [x] Requires: https://github.com/hdl/conda-eda/pull/118
- [x] Requires: https://github.com/SymbiFlow/edalize/pull/104

This PR updates yosys-uhdm conda package to use ``uhdm`` frontend as a plugin to ``yosys``.

