### PR TITLE
results: add also failed meta results

### DIFF
--- a/conf/nextpnr/environment.yml
+++ b/conf/nextpnr/environment.yml
@@ -10,6 +10,8 @@ dependencies:
   - litex-hub::nextpnr-ice40=0.0.0_3403_g3fd1ee77=20210722_152338_py37
   - litex-hub::nextpnr-xilinx=v0.0_2840_g86500ec6=20210722_152338_py37
   - litex-hub::nextpnr-nexus=0.0.0_3403_g3fd1ee77=20210813_070938_py37
+    # FIXME: Pin prjoxide as newer packages require glibc 2.29
+  - litex-hub::prjoxide=v0.0_407_g026e545=20210923_082942
   - litex-hub::prjxray-db=0.0_252_g8372b58=20210723_083625
   - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
   - litex-hub::capnproto=0.8.0=20210316_201220

--- a/exhaust.py
+++ b/exhaust.py
@@ -87,22 +87,24 @@ def print_summary_table(
 
         # Check if metadata was generated
         # It is created for successful builds only
-        if os.path.exists(os.path.join(root_dir, out_prefix, build,
-                                       'meta.json')):
-            row.append(colored('passed', 'green'))
-            passed += 1
-        else:
-            if is_required:
-                row.append(colored('failed', 'red'))
-
-                build_status = False
-                failed_required_tests.append(
-                    "{} {} {}".format(row[0], row[1], row[4])
-                )
+        with open(os.path.join(root_dir, out_prefix, build, 'meta.json')) as meta:
+            meta_data = json.load(meta)
+            if meta_data["status"] == "succeeded":
+                row.append(colored('passed', 'green'))
+                passed += 1
             else:
-                row.append(colored('allowed to fail', 'blue'))
+                assert meta_data["status"] == "failed"
+                if is_required:
+                    row.append(colored('failed', 'red'))
 
-            failed += 1
+                    build_status = False
+                    failed_required_tests.append(
+                        "{} {} {}".format(row[0], row[1], row[4])
+                    )
+                else:
+                    row.append(colored('allowed to fail', 'blue'))
+
+                failed += 1
 
         table_data.append(row)
         build_count += 1

--- a/exhaust.py
+++ b/exhaust.py
@@ -87,7 +87,8 @@ def print_summary_table(
 
         # Check if metadata was generated
         # It is created for successful builds only
-        with open(os.path.join(root_dir, out_prefix, build, 'meta.json')) as meta:
+        with open(os.path.join(root_dir, out_prefix, build,
+                               'meta.json')) as meta:
             meta_data = json.load(meta)
             if meta_data["status"] == "succeeded":
                 row.append(colored('passed', 'green'))

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -166,7 +166,7 @@ def run(
     device = board_info['device']
     package = board_info['package']
 
-    assert family == 'ice40' or family == 'xc7' or family == 'eos' or family == 'lifcl'
+    assert family == 'ice40' or family == 'xc7' or family == 'eos' or family == 'nexus'
 
     # some toolchains use signed 32 bit
     assert seed is None or 0 <= seed <= 0x7FFFFFFF

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -214,7 +214,9 @@ def run(
         try:
             t.run()
         except Exception as e:
-            output_error = "[...]\n{}".format(str(e)[-1000:]) if len(str(e)) > 1000 else str(e)
+            output_error = "[...]\n{}".format(
+                str(e)[-1000:]
+            ) if len(str(e)) > 1000 else str(e)
             output_error = output_error.split("\n")
 
     logger.debug("Printing Stats")

--- a/infrastructure/runner.py
+++ b/infrastructure/runner.py
@@ -56,40 +56,23 @@ class Runner:
 
         build = self.build_format.format(build_number)
 
-        # We don't want output of all subprocesses here
-        # Log files for each build will be placed in build directory
         with redirect_stdout(open(os.devnull, 'w')):
-            try:
-                run(
-                    board,
-                    toolchain,
-                    project,
-                    None,  #params_file
-                    option,  #params_string
-                    None,  #out_dir
-                    self.out_prefix,
-                    self.overwrite,
-                    self.verbose,
-                    None,  #strategy
-                    seed,
-                    None,  #carry
-                    build,
-                    self.build_type,
-                )
-            except Exception as e:
-                eprint("\n---------------------")
-                eprint(
-                    "ERROR: {} {} {} test has failed (build type {}, build nr. {})\n"
-                    .format(project, toolchain, board, self.build_type, build)
-                )
-                # Limit output to max 300 characters for exhaust.py to make sure log files are not too large.
-                exception_str = str(e)
-                eprint(
-                    "ERROR MESSAGE: ",
-                    ("[...]\n{}".format(exception_str[-1000:]))
-                    if len(str(exception_str)) > 1000 else exception_str
-                )
-                eprint("---------------------\n")
+            run(
+                board,
+                toolchain,
+                project,
+                None,  #params_file
+                option,  #params_string
+                None,  #out_dir
+                self.out_prefix,
+                self.overwrite,
+                self.verbose,
+                None,  #strategy
+                seed,
+                None,  #carry
+                build,
+                self.build_type,
+            )
 
     def run(self):
         os.makedirs(os.path.expanduser(self.out_prefix), exist_ok=True)

--- a/other/boards.json
+++ b/other/boards.json
@@ -50,7 +50,7 @@
         "package": "PD64"
     },
     "lifcl-40": {
-        "family": "lifcl",
+        "family": "nexus",
         "device": "LIFCL-40-9BG400CES",
         "package": "None"
     }

--- a/project/axi-lite-reg.json
+++ b/project/axi-lite-reg.json
@@ -9,5 +9,5 @@
         "xilinx": ["zybo"]
     },
     "required_toolchains": ["vivado", "vpr"],
-    "skip_toolchains": ["nextpnr-fpga-interchange"]
+    "skip_toolchains": ["nextpnr-fpga-interchange", "yosys-vivado-uhdm", "yosys-vivado", "vpr-fasm2bels"]
 }

--- a/project/dram-test-64x1d.json
+++ b/project/dram-test-64x1d.json
@@ -15,7 +15,7 @@
         "clk": 10.0
     },
     "clock_aliases": {
-        "clk": ["dram_test.cl"]
+        "clk": ["dram_test.clk"]
     },
     "vendors": {
         "xilinx": ["basys3", "nexys-video"]

--- a/results/fetch_meta.py
+++ b/results/fetch_meta.py
@@ -79,6 +79,11 @@ def merge_results(metas, filter=None):
     earliest_dt = datetime.now()
     projects = defaultdict(lambda: {'results': defaultdict(lambda: [])})
 
+    res_types = [
+        'board', 'toolchain', 'runtime', 'resources', 'maximum_memory_use',
+        'max_freq', 'device', 'status'
+    ]
+
     for meta in metas:
         try:
             dt = datetime_from_str(meta['date'])
@@ -92,13 +97,8 @@ def merge_results(metas, filter=None):
                     continue
 
             # This is a rather incomplete list, but it should do the job
-            results['board'].append(meta['board'])
-            results['toolchain'].append(meta['toolchain'])
-            results['runtime'].append(meta['runtime'])
-            results['resources'].append(meta['resources'])
-            results['maximum_memory_use'].append(meta['maximum_memory_use'])
-            results['max_freq'].append(meta['max_freq'])
-            results['device'].append(meta['device'])
+            for res_type in res_types:
+                results[res_type].append(meta[res_type])
 
         except KeyError as e:
             print(f'Skipping a meta file because of {e}')
@@ -147,26 +147,17 @@ def download_and_split_compound(gcs_compound_path: str):
     projects = defaultdict(lambda: {'results': defaultdict(lambda: [])})
 
     meta_results = meta['results']
-    zipped = zip(
-        meta_results['board'], meta_results['project'],
-        meta_results['toolchain'], meta_results['runtime'],
-        meta_results['resources'], meta_results['maximum_memory_use'],
-        meta_results['max_freq'], meta_results['device'],
-        meta_results['wirelength']
-    )
 
-    for board, project, toolchain, runtime, resources, maximum_mem_use, \
-            max_freq, device, wirelength in zipped:
+    meta_projects = meta_results['project']
 
+    for idx, project in enumerate(meta_projects):
         project_res = projects[project]['results']
-        project_res['board'].append(board)
-        project_res['toolchain'].append(toolchain)
-        project_res['runtime'].append(runtime)
-        project_res['resources'].append(resources)
-        project_res['maximum_memory_use'].append(maximum_mem_use)
-        project_res['max_freq'].append(max_freq)
-        project_res['device'].append(device)
-        project_res['wirelength'].append(wirelength)
+
+        for k, v in meta_results.items():
+            if k in ['project']:
+                continue
+
+            project_res[k].append(v[idx])
 
     for project in projects.values():
         project['date'] = meta['date']

--- a/results/generate_html.py
+++ b/results/generate_html.py
@@ -48,7 +48,7 @@ def main():
     graph_viz_template = env.get_template('graphviz.html')
     index_template = env.get_template('index.html')
 
-    results = []
+    results = list()
 
     for project_name in os.listdir(args.in_dir):
         project_dir = os.path.join(args.in_dir, project_name)
@@ -56,9 +56,12 @@ def main():
             print(f'Skipping `{project_dir}` because it' 's not a directory.')
             continue
 
-        project_results = ProjectResults(project_name, project_dir)
+        # Do not filter failed tests
+        project_results = ProjectResults(project_name, project_dir, False)
         results.append(project_results)
 
+        # Filter failed tests
+        project_results = ProjectResults(project_name, project_dir, True)
         graph_pages[project_name] = \
             generate_graph_html(graph_viz_template, project_results)
 

--- a/results/generate_index_page.py
+++ b/results/generate_index_page.py
@@ -35,7 +35,6 @@ def generate_index_html(
     toolchains_dict = dict()
     projects = set()
     for project, toolchain, board in combinations:
-        print(project, toolchain, board)
         if board not in boards:
             boards[board] = dict()
 

--- a/results/project_results.py
+++ b/results/project_results.py
@@ -30,7 +30,7 @@ class ProjectResults:
     test_dates: 'list[datetime]'
     entries: 'defaultdict[str, defaultdict[str, list[TestEntry]]]'
 
-    def __init__(self, project_name: str, data_dir: str):
+    def __init__(self, project_name: str, data_dir: str, filter_failed: bool):
         self.project_name = project_name
         self.test_dates = []
         self.entries = defaultdict(lambda: defaultdict(lambda: []))
@@ -58,6 +58,9 @@ class ProjectResults:
             configs_to_handle = {}
 
             for board, toolchain, entry in get_entries(data):
+                if entry.status == "failed" and filter_failed:
+                    continue
+
                 self.entries[board][toolchain].append(entry)
 
     def get_all_configs(self):

--- a/results/testentry.py
+++ b/results/testentry.py
@@ -82,7 +82,17 @@ def null_generator():
 def get_entries(json_data: dict):
     results = json_data['results']
 
-    def make_clks(clkdef: 'dict | float'):
+    def make_clks(clkdef: 'dict | float | None'):
+        def get_clk(freq):
+            clk = Clk()
+            clk.actual = freq
+            clk.hold_violation = 0.0
+            clk.met = False
+            clk.requested = 0.0
+            clk.setup_violation = 0.0
+
+            return clk
+
         clks = {}
         if type(clkdef) is dict:
             for clkname, clkvals in clkdef.items():
@@ -91,32 +101,30 @@ def get_entries(json_data: dict):
                     setattr(clk, k, v)
                 clks[clkname] = clk
         elif type(clkdef) is float:
-            clk = Clk()
-            clk.actual = clkdef
-            clk.hold_violation = 0.0
-            clk.met = False
-            clk.requested = 0.0
-            clk.setup_violation = 0.0
-            clks['clk'] = clk
+            clks['clk'] = get_clk(clkdef)
+        elif clkdef is None:
+            clks['clk'] = get_clk(0.0)
         else:
             raise Exception('Wrong type for clock definition')
         return clks
 
-    def make_runtime(runtimedef: dict):
+    def make_runtime(runtimedef: 'dict | None'):
         runtime = Runtime()
-        for k, v in runtimedef.items():
-            k = k.replace(' ', '_')
-            setattr(runtime, k, v)
+        if type(runtimedef) is dict:
+            for k, v in runtimedef.items():
+                k = k.replace(' ', '_')
+                setattr(runtime, k, v)
         return runtime
 
-    def make_resources(resourcesdef: dict):
+    def make_resources(resourcesdef: 'dict | None'):
         resources = Resources()
-        for k, v in resourcesdef.items():
-            k = k.lower()
-            if v is None:
-                v = 'null'
-            setattr(resources, k, v)
-        resources.sanitize()
+        if type(resourcesdef) is dict:
+            for k, v in resourcesdef.items():
+                k = k.lower()
+                if v is None:
+                    v = 'null'
+                setattr(resources, k, v)
+            resources.sanitize()
         return resources
 
     wirelength = results.get('wirelength', null_generator())

--- a/toolchains/toolchain.py
+++ b/toolchains/toolchain.py
@@ -23,7 +23,6 @@ import shutil
 
 from utils.utils import Timed, have_exec
 
-
 TOOLCHAIN_MAP = {
     'vpr': ('yosys', 'vpr'),
     'vpr-fasm2bels': ('yosys', 'vpr'),
@@ -37,6 +36,7 @@ TOOLCHAIN_MAP = {
     'nextpnr-xilinx-fasm2bels': ('yosys', 'nextpnr'),
     'quicklogic': ('yosys', 'vpr'),
 }
+
 
 class Toolchain:
     '''A toolchain takes in verilog files and produces a .bitstream'''
@@ -375,12 +375,14 @@ class Toolchain:
             'build': self.build,
             'build_type': self.build_type,
             'date': date_str,
-            'toolchain': {
-                self.toolchain: {
-                    'synthesis_tool': synth_tool,
-                    'pr_tool': pr_tool,
+            'toolchain':
+                {
+                    self.toolchain:
+                        {
+                            'synthesis_tool': synth_tool,
+                            'pr_tool': pr_tool,
+                        },
                 },
-            },
             'strategy': self.strategy,
             'parameters': self.params_file or self.params_string,
 

--- a/toolchains/toolchain.py
+++ b/toolchains/toolchain.py
@@ -240,10 +240,6 @@ class Toolchain:
         print("Running: %s %s" % (cmd, argstr))
         self.cmds.append('%s %s' % (cmd, argstr))
 
-        # Use this to checkpoint various stages
-        # If a command fails, we'll have everything up to it
-        self.write_metadata(all=False)
-
         cmd_base = os.path.basename(cmd)
         with open("%s/%s.txt" % (self.out_dir, cmd_base), "w") as f:
             f.write("Running: %s %s\n\n" % (cmd_base, argstr))
@@ -348,7 +344,7 @@ class Toolchain:
                 ]
             )
 
-        assert max_freq, "ERROR: no clocks assigned for this test design!"
+        assert max_freq, f"ERROR: no clocks assigned for this test design! {self.design()}"
 
         return max_freq, resources
 


### PR DESCRIPTION
This PR does the following:

- lets the toolchains output a failed/succeeded status field in the meta.json. If a task fails, the error message gets attached to the meta.json.
- the initial view of the results gh page displays the set of all available boards, and for each, all the designs enabled for them and the currently passing toolchains.