### PR TITLE
results: add DSP usage information

### DIFF
--- a/results/generate_index_page.py
+++ b/results/generate_index_page.py
@@ -126,10 +126,10 @@ def generate_graph_data(device, toolchain, dates, entries):
     attrs['maximum_memory_use'] = list()
     attrs['wirelength'] = list()
     attrs['synth_resources'] = [
-        'lut', 'dff', 'carry', 'iob', 'bram', 'pll', 'glb'
+        'lut', 'dff', 'carry', 'iob', 'bram', 'dsp', 'pll', 'glb'
     ]
     attrs['impl_resources'] = [
-        'lut', 'dff', 'carry', 'iob', 'bram', 'pll', 'glb'
+        'lut', 'dff', 'carry', 'iob', 'bram', 'dsp', 'pll', 'glb'
     ]
 
     for k, v in attrs.items():
@@ -161,7 +161,9 @@ def generate_device_data(results: ProjectResults):
     results_entries = results.entries
     project_name = results.project_name
     dates = results.test_dates
-    resources_list = ["LUT", "DFF", "CARRY", "IOB", "BRAM", "PLL", "GLB"]
+    resources_list = [
+        "LUT", "DFF", "CARRY", "IOB", "BRAM", "DSP", "PLL", "GLB"
+    ]
     runtimes_list = [
         'total', 'fasm', 'synthesis', 'packing', 'placement', 'routing',
         'bitstream', 'overhead'

--- a/results/result_entry.py
+++ b/results/result_entry.py
@@ -30,6 +30,7 @@ class Resources:
     iob: int
     lut: int
     pll: int
+    dsp: int
 
     def sanitize(self):
         # FIXME: currenly oxide uses FF instead of DFF, lacks GLB and has LRAM
@@ -42,6 +43,8 @@ class Resources:
         # empty GLB
         if not hasattr(self, 'glb'):
             self.glb = 0
+        if not hasattr(self, 'dsp'):
+            self.dsp = 0
         # ignore LRAM
         if hasattr(self, 'lram'):
             del self.lram

--- a/toolchains/nextpnr.py
+++ b/toolchains/nextpnr.py
@@ -549,12 +549,50 @@ class NextpnrOxide(NextpnrGeneric):
         self.nextpnr_log = "next.log"
 
         self.resources_map = {
-            'LUT': ('OXIDE_COMB'),
-            'DFF': ('OXIDE_FF'),
-            'CARRY': ('CCU2'),
-            'IOB': ('SEIO33_CORE'),
-            'PLL': ('PLL_CORE'),
-            'BRAM': ('OXIDE_EBR', 'LRAM_CORE'),
+            'LUT': (
+                'OXIDE_COMB',
+                'LUT4',
+            ),
+            'DFF': (
+                'OXIDE_FF',
+                'FD1P3IX',
+                'FD1P3BX',
+                'FD1P3JX',
+            ),
+            'CARRY': (
+                ('OXIDE_COMB', 0.5),
+                'CCU2',
+            ),
+            'IOB':
+                (
+                    'SEIO33_CORE',
+                    'SEIO18_CORE',
+                    ('DIFFIO18_CORE', 2),
+                    'IB',
+                    'OB',
+                ),
+            'PLL': (
+                'OSC_CORE',
+                'PLL_CORE',
+                'OSCA',
+            ),
+            'BRAM':
+                (
+                    'OXIDE_EBR',
+                    'LRAM_CORE',
+                    'PDP16K',
+                    'PDPSC16K',
+                    'SP512K',
+                ),
+            'DSP':
+                (
+                    'MULT18_CORE',
+                    'MULT18X36_CORE',
+                    'MULT36_CORE',
+                    'MULT18X18',
+                    'MULT36X36',
+                    'MULT9X9',
+                )
         }
 
     def prepare_edam(self):

--- a/toolchains/nextpnr.py
+++ b/toolchains/nextpnr.py
@@ -367,7 +367,8 @@ class NextpnrFPGAInterchange(NextpnrGeneric):
                 'BRAMS',
                 'RAMB18E1',
                 ('RAMB36E1', 2),
-            )
+            ),
+            'DSP': ('DSP48E1')
         }
 
     def prepare_edam(self):
@@ -503,6 +504,7 @@ class NextpnrXilinx(NextpnrGeneric):
                     'RAMB18E1',
                     ('RAMB36E1', 2),
                 ),
+            'DSP': ('DSP48E1_DSP48E1', 'DSP48E1')
         }
 
     def prepare_edam(self):

--- a/toolchains/symbiflow.py
+++ b/toolchains/symbiflow.py
@@ -63,6 +63,7 @@ class VPR(Toolchain):
                     ('RAMB36E1', 2),
                     ('RAMB36E1_PRIM', 2),
                 ),
+            'DSP': (),
         }
 
     def prepare_edam(self, part):
@@ -562,6 +563,7 @@ class Quicklogic(VPR):
             ),
             'PLL': (),
             'BRAM': (),
+            'DSP': (),
         }
 
     def run(self):

--- a/toolchains/toolchain.py
+++ b/toolchains/toolchain.py
@@ -349,8 +349,10 @@ class Toolchain:
             for source in ["synth", "impl"]:
                 resources[source] = dict(
                     [
-                        (x, None) for x in
-                        ('LUT', 'DFF', 'BRAM', 'CARRY', 'GLB', 'PLL', 'IOB')
+                        (x, None) for x in (
+                            'LUT', 'DFF', 'BRAM', 'CARRY', 'GLB', 'PLL', 'IOB',
+                            'DSP'
+                        )
                     ]
                 )
 

--- a/toolchains/toolchain.py
+++ b/toolchains/toolchain.py
@@ -9,17 +9,17 @@
 #
 # SPDX-License-Identifier: ISC
 
-import os
-import subprocess
-import time
 import collections
+import datetime
+import glob
 import json
+import math
+import os
 import re
 import shutil
+import subprocess
 import sys
-import glob
-import datetime
-import shutil
+import time
 
 from utils.utils import Timed, have_exec, get_file_dict
 
@@ -307,9 +307,9 @@ class Toolchain:
                     multiplier = 1
 
                 if res_name in resources:
-                    resources_count[res_type] += int(
-                        resources[res_name]
-                    ) * multiplier
+                    resources_count[res_type] += math.floor(
+                        int(resources[res_name]) * multiplier
+                    )
 
         for res_type, res_count in resources_count.items():
             resources_count[res_type] = str(res_count)

--- a/toolchains/vivado.py
+++ b/toolchains/vivado.py
@@ -71,6 +71,7 @@ class Vivado(Toolchain):
                 'RAMB18E1',
                 ('RAMB36E1', 2),
             ),
+            'DSP': ('DSP48E1', ),
         }
 
     def get_vivado_runtimes(self, logfile):


### PR DESCRIPTION
This PR also fixes resources gathering for nexus. Fixes issue https://github.com/SymbiFlow/fpga-tool-perf/issues/367 and https://github.com/SymbiFlow/fpga-tool-perf/issues/368.

There is only an issue which I am not sure how to fix around the LUT4 and Carry chains usage, as in the nextpnr log, both of the resources are expressed combined in the `OXIDE_COMB` element, so the final implementation resources might be misleading.