### PR TITLE
gh-actions: add custom runners to parallelize jobs

### DIFF
--- a/.github/workflows/scripts/generate_job_matrix.py
+++ b/.github/workflows/scripts/generate_job_matrix.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+from fpgaperf import get_combinations
+
+jobs = list()
+for combination in get_combinations():
+    project, toolchain, board = combination
+
+    jobs.append(dict(project=project, toolchain=toolchain, board=board))
+
+print('::set-output name=matrix::' + str(jobs))

--- a/.github/workflows/scripts/generate_job_matrix.py
+++ b/.github/workflows/scripts/generate_job_matrix.py
@@ -15,6 +15,11 @@ jobs = list()
 for combination in get_combinations():
     project, toolchain, board = combination
 
+    # TODO: different matrices need to be produced, otherwise the 256 jobs limit is reached
+    #       for now test only vivado and vpr tests
+    if toolchain not in ["vivado", "vpr"]:
+        continue
+
     jobs.append(dict(project=project, toolchain=toolchain, board=board))
 
 print('::set-output name=matrix::' + str(jobs))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,76 @@
+on: [push, pull_request]
+
+name: Full Test Suite
+
+jobs:
+
+  Matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Generate Matrix
+        id: generate
+        run: |
+          python3 -m pip install -r conf/common/requirements.txt
+          PYTHONPATH=$(pwd) python3 ./.github/workflows/scripts/generate_job_matrix.py
+
+  Test:
+    needs: Matrix
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.Matrix.outputs.matrix) }}
+
+    env:
+      GHA_EXTERNAL_DISK: "tools"
+      GHA_PREEMPTIBLE: "false"
+
+    container: ubuntu:bionic
+
+    runs-on: [self-hosted, Linux, X64]
+
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Install
+        run: |
+          apt update
+          ln -s /mnt/aux/Xilinx /opt/Xilinx
+          source /opt/Xilinx/Vivado/2017.2/settings64.sh
+          vivado -version
+          # Make environments
+          make install_symbiflow
+          make install_quicklogic
+          make install_interchange
+          TOOLCHAIN=symbiflow make env
+          TOOLCHAIN=quicklogic make env
+          TOOLCHAIN=nextpnr make env
+
+      - name: Run Test
+        run: |
+          source env.sh
+          # Testing all projects/toolchains/boards
+          python3 exhaust.py --project ${{ matrix.project }} --toolchain ${{matrix.toolchain }} --board ${{ matrix.board }} --build_type generic-all --fail
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: |
+            **/*.txt
+            **/plot_*.svg

--- a/fpgaperf.py
+++ b/fpgaperf.py
@@ -229,6 +229,30 @@ def run(
     t.write_metadata(output_error)
 
 
+def get_combinations():
+    """ Returns a list of tuples with all the possible combinations of supported builds """
+    combs = list()
+    for p in get_projects():
+        toolchain_info = get_project(p)["required_toolchains"]
+        vendor_info = get_project(p)["vendors"]
+        for t in get_toolchains():
+            vendor = get_vendors(t)
+            if vendor not in vendor_info:
+                continue
+
+            board_info = vendor_info[vendor]
+            for b in get_boards():
+                if b not in get_vendors()[vendor]["boards"]:
+                    continue
+
+                if board_info is None or b not in board_info:
+                    continue
+
+                combs.append((p, t, b))
+
+    return combs
+
+
 def list_combinations(
     project=None,
     toolchain=None,


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to enable a matrix computation of all the possible tests run by CI. It spawns one runner for each combination among all the possible valid tests combinations.

A follow-up PR would be the one to upload the results to a GCP or another location, and download from there the results to display in the dashboard.